### PR TITLE
Update openQA test cases using current os-autoinst

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -151,7 +151,7 @@ sub ensure_installed {
 sub script_sudo($$) {
     my ($self, $prog, $wait) = @_;
 
-    send_key 'ctrl-l';
+    type_string "clear\n";
     type_string "su -c '$prog'\n";
     if (!get_var("LIVETEST")) {
         assert_screen 'password-prompt';
@@ -168,7 +168,7 @@ sub become_root() {
     type_string "whoami > /dev/$testapi::serialdev\n";
     wait_serial( "root", 2 ) || die "Root prompt not there";
     type_string "cd /tmp\n";
-    send_key('ctrl-l');
+    type_string "clear\n";
 }
 
 1;

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1,0 +1,16 @@
+package utils;
+
+use base Exporter;
+use Exporter;
+use strict;
+use testapi;
+
+our @EXPORT = qw/wait_for_desktop/;
+
+sub wait_for_desktop {
+    check_screen [qw/boot-menu openqa-desktop/];
+    send_key 'ret' if match_has_tag 'boot-menu';
+    assert_screen "openqa-desktop", 500;
+}
+
+1;

--- a/main.pm
+++ b/main.pm
@@ -11,22 +11,22 @@ testapi::set_distribution(susedistribution->new());
 
 sub loadtest($) {
     my ($test) = @_;
-    autotest::loadtest(get_var("CASEDIR") . "/tests/$test");
+    autotest::loadtest("/tests/$test");
 }
 
 # subs for test types
-sub load_update_tests(){
+sub load_update_tests() {
     loadtest "update/zypper_up.pm";
     loadtest "update/reboot.pm";
 }
 
-sub load_osautoinst_tests(){
+sub load_osautoinst_tests() {
     loadtest "osautoinst/worker.pm";
     loadtest "osautoinst/start_test.pm";
     loadtest "osautoinst/test_running.pm";
 }
 
-sub load_openQA_tests(){
+sub load_openQA_tests() {
     loadtest "openQA/dashboard.pm";
     loadtest "openQA/login.pm";
     loadtest "openQA/build_results.pm";

--- a/tests/openQA/admin.pm
+++ b/tests/openQA/admin.pm
@@ -4,19 +4,19 @@ use testapi;
 
 sub run {
     assert_and_click 'openqa-admin-link';
-    assert_screen 'openqa-admin-users', 5;
+    assert_screen 'openqa-admin-users';
     assert_and_click 'openqa-admin-medium-link';
-    assert_screen 'openqa-admin-medium', 5;
+    assert_screen 'openqa-admin-medium';
     assert_and_click 'openqa-admin-machines-link';
-    assert_screen 'openqa-admin-machines', 5;
+    assert_screen 'openqa-admin-machines';
     assert_and_click 'openqa-admin-testsuite-link';
-    assert_screen 'openqa-admin-testsuite', 5;
+    assert_screen 'openqa-admin-testsuite';
     assert_and_click 'openqa-admin-jobgroup-link';
-    assert_screen 'openqa-admin-jobgroup', 5;
+    assert_screen 'openqa-admin-jobgroup';
     assert_and_click 'openqa-admin-assets-link';
-    assert_screen 'openqa-admin-assets', 5;
+    assert_screen 'openqa-admin-assets';
     assert_and_click 'openqa-admin-workers-link';
-    assert_screen 'openqa-admin-workers', 5;
+    assert_screen 'openqa-admin-workers';
 }
 
 1;

--- a/tests/openQA/build_results.pm
+++ b/tests/openQA/build_results.pm
@@ -4,7 +4,7 @@ use testapi;
 
 sub run {
     assert_and_click 'openqa-build0002';
-    assert_screen 'openqa-buildresults', 5;
+    assert_screen 'openqa-buildresults';
 }
 
 1;

--- a/tests/openQA/login.pm
+++ b/tests/openQA/login.pm
@@ -4,8 +4,7 @@ use testapi;
 
 sub run {
     assert_and_click 'openqa-login';
-    sleep 5;
-    assert_screen 'openqa-logged-in', 10;
+    assert_screen 'openqa-logged-in';
 }
 
 1;

--- a/tests/openQA/test_live.pm
+++ b/tests/openQA/test_live.pm
@@ -4,12 +4,12 @@ use testapi;
 
 sub run {
     assert_and_click 'openqa-running-test';
-    assert_screen 'openqa-liveresults', 5;
+    assert_screen 'openqa-liveresults';
     send_key 'pgdn';
-    assert_screen 'openqa-liveresults-2', 5;
+    assert_screen 'openqa-liveresults-2';
     send_key 'pgdn';
     send_key 'pgdn';
-    assert_screen 'openqa-liveresults-3', 5;
+    assert_screen 'openqa-liveresults-3';
     send_key 'pgup';
     send_key 'pgup';
     send_key 'pgup';

--- a/tests/openQA/test_results.pm
+++ b/tests/openQA/test_results.pm
@@ -4,17 +4,24 @@ use testapi;
 
 sub run {
     assert_and_click 'openqa-home';
-    assert_screen 'openqa-dashboard', 5;
-    assert_and_click 'openqa-build0001';
-    assert_screen 'openqa-buildresults', 5;
+    assert_screen 'openqa-dashboard';
+    # since the build image is very old all results already disappeared from
+    # the dashboard. As there is no link to all test results in this old
+    # version we have to workaround this by explicitly selecting the '/tests'
+    # subroute
+    send_key 'f6';
+    send_key 'right';
+    type_string "/tests\n";
+    assert_and_click 'openqa-tests-build0001';
+    assert_screen 'openqa-buildresults';
     assert_and_click 'openqa-passed-test';
-    assert_screen 'openqa-testresults', 5;
+    assert_screen 'openqa-testresults';
     assert_and_click 'openqa-needle';
-    assert_screen 'openqa-screenshot', 5;
+    assert_screen 'openqa-screenshot';
     assert_and_click 'openqa-needle-editor';
-    assert_screen 'openqa-needle-editor-screen', 5;
+    assert_screen 'openqa-needle-editor-screen';
     assert_and_click 'openqa-source-code';
-    assert_screen 'openqa-source-screen', 5;
+    assert_screen 'openqa-source-screen';
 }
 
 1;

--- a/tests/openQA/tests.pm
+++ b/tests/openQA/tests.pm
@@ -4,7 +4,7 @@ use testapi;
 
 sub run {
     assert_and_click 'openqa-test-link';
-    assert_screen 'openqa-testscreen', 5
+    assert_screen 'openqa-testscreen';
 }
 
 1;

--- a/tests/osautoinst/start_test.pm
+++ b/tests/osautoinst/start_test.pm
@@ -5,7 +5,7 @@ use testapi;
 sub run {
     validate_script_output '/usr/share/openqa/script/client isos post ISO=openSUSE-13.2-DVD-x86_64.iso DISTRI=opensuse VERSION=13.2 FLAVOR=DVD ARCH=x86_64 BUILD=0002', sub { m/1/ };
     save_screenshot;
-    send_key 'ctrl-l';
+    type_string "clear\n";
 }
 
 1;

--- a/tests/osautoinst/test_running.pm
+++ b/tests/osautoinst/test_running.pm
@@ -5,7 +5,7 @@ use testapi;
 sub run {
     validate_script_output "/usr/share/openqa/script/client jobs state=running", sub { m/"running"/ };
     save_screenshot;
-    send_key "ctrl-l";
+    type_string "clear\n";
 }
 
 1;

--- a/tests/osautoinst/worker.pm
+++ b/tests/osautoinst/worker.pm
@@ -1,20 +1,21 @@
 use strict;
 use base "openQAcoretest";
 use testapi;
+use utils;
 
 sub run {
-    assert_screen 'openqa-desktop', 500;
+    wait_for_desktop;
     send_key 'ctrl-alt-f2';
     assert_screen 'inst-console';
     type_string "root\n";
     assert_screen 'password-prompt', 10;
     type_string "1\n";
-    sleep 3;
-    type_string "PS1=\$\n";
-    sleep 1;
+    wait_still_screen(2);
+    type_string "PS1='# '\n";
+    wait_still_screen(1);
     validate_script_output 'systemctl status openqa-worker@1', sub { m/\Qactive (running)\E/ };
     save_screenshot;
-    send_key 'ctrl-l';
+    type_string "clear\n";
 }
 
 1;

--- a/tests/update/reboot.pm
+++ b/tests/update/reboot.pm
@@ -1,10 +1,11 @@
 use strict;
 use base "openQAcoretest";
 use testapi;
+use utils;
 
 sub run {
     type_string "systemctl reboot\n";
-    assert_screen "openqa-desktop", 500;
+    wait_for_desktop;
 }
 
 1;

--- a/tests/update/zypper_up.pm
+++ b/tests/update/zypper_up.pm
@@ -1,23 +1,26 @@
 use strict;
 use base "openQAcoretest";
 use testapi;
+use utils;
 
 sub run {
-    assert_screen "openqa-desktop", 500;
+    wait_for_desktop;
     send_key "ctrl-alt-f2";
     assert_screen "inst-console";
     type_string "root\n";
-    assert_screen "password-prompt", 10;
+    assert_screen "password-prompt";
     type_string "1\n";
-    sleep 3;
-    type_string "PS1=\$\n";
-    sleep 1;
+    wait_still_screen(2);
+    type_string "PS1='# '\n";
+    wait_still_screen(1);
     script_run "systemctl mask packagekit.service";
     script_run "systemctl stop packagekit.service";
     save_screenshot;
-    send_key "ctrl-l";
-    script_run("zypper -n up --auto-agree-with-licenses && echo 'worked-up' > /dev/$serialdev");
-    die "zypper failed" unless wait_serial "worked-up", 700;
+    type_string "clear\n";
+    # there is no main openqa repo for openSUSE13.2 anymore but stable
+    type_string "zypper rr openQA\n";
+    type_string "zypper ar http://download.opensuse.org/repositories/devel:/openQA:/stable/openSUSE_13.2 openQA-stable\n";
+    assert_script_run('zypper -n up --auto-agree-with-licenses', timeout => 700, fail_message => 'zypper failed to update packages');
     save_screenshot;
 }
 


### PR DESCRIPTION
What we learned and applied in os-autoinst-distri-opensuse has been applied
here, e.g. replacing hardcoded sleep periods by "wait_still_screen", calling
"clear\n" instead of "ctrl-l" and default timeouts for assert_screen for
better performance depending robustness.

Since time has passed since the tests have been setup the finished job
actually present in the image used is very old and therefore does not show up
in the dashboard and also the currently installed version does not have an
"All Tests Result" link. Therefore firefox is instructed to go to the tests by
altering the URL. Needles are updated therefore.

openSUSE 13.2 as used as a base here and openQA is not built in the current
development version for openSUSE 13.2 so I remove the obsolete repo and
"monkey patch" the "stable" repo.

So far tested with the upgrades disabled so actually the already installed
version. With updates, i.e. the current stable version, will come.

Corresponding needle PR: https://github.com/os-autoinst/os-autoinst-needles-openQA/pull/1

screenshot of local verification:
![local_verification_os_autoinst_distri_openqa](https://cloud.githubusercontent.com/assets/1693432/16173279/7ba2baf4-359c-11e6-8405-29ce81beb991.png)

