### PR TITLE
start_test: Prevent openqa host access problems

### DIFF
--- a/lib/openQAcoretest.pm
+++ b/lib/openQAcoretest.pm
@@ -1,10 +1,10 @@
 package openQAcoretest;
 use base "basetest";
 
-# All steps belonging to core openQA functionality are 'fatal'.
+# All steps belonging to core openQA functionality are 'fatal'. by default
 
-sub test_flags() {
-    return { 'fatal' => 1 };
+sub test_flags {
+    return { fatal => 1 };
 }
 
 1;

--- a/tests/osautoinst/start_test.pm
+++ b/tests/osautoinst/start_test.pm
@@ -4,7 +4,7 @@ use testapi;
 
 sub run {
     if (check_var('VERSION', '13.2')) {
-        validate_script_output 'openqa-client isos post ISO=openSUSE-13.2-DVD-x86_64.iso DISTRI=opensuse VERSION=13.2 FLAVOR=DVD ARCH=x86_64 BUILD=0002', sub { m/1/ };
+        assert_script_run 'openqa-client isos post ISO=openSUSE-13.2-DVD-x86_64.iso DISTRI=opensuse VERSION=13.2 FLAVOR=DVD ARCH=x86_64 BUILD=0002';
     }
     else {
         # please forgive the hackiness: using the openQA API but parsing the

--- a/tests/osautoinst/start_test.pm
+++ b/tests/osautoinst/start_test.pm
@@ -7,17 +7,18 @@ sub run {
         validate_script_output '/usr/share/openqa/script/client isos post ISO=openSUSE-13.2-DVD-x86_64.iso DISTRI=opensuse VERSION=13.2 FLAVOR=DVD ARCH=x86_64 BUILD=0002', sub { m/1/ };
     }
     else {
-    # please forgive the hackiness: using the openQA API but parsing the
-    # human-readable output of 'client' to get the most recent job of
-    # 'memtest', a small test scenario on a small iso to clone
-    my $cmd = <<'EOF';
-last_tw_build=$(/usr/share/openqa/script/client --host https://openqa.opensuse.org assets get | sed -n 's/^.*name.*Tumbleweed-NET-x86_64-Snapshot\([0-9]\+\)-Media.*$/\1/p' | sort -n | tail -n 1)
-echo "Last Tumbleweed build on openqa.opensuse.org: $last_tw_build"
-job_id=$(/usr/share/openqa/script/client --host https://openqa.opensuse.org jobs get version=Tumbleweed scope=relevant arch=x86_64 build=$last_tw_build flavor=NET | grep -B 8 'name.*memtest' | sed -n 's/^\s*\<id.*=> \([0-9]\+\).*$/\1/p')
-echo "scenario x86_64-memtest-NET: $job_id"
+        # please forgive the hackiness: using the openQA API but parsing the
+        # human-readable output of 'client' to get the most recent job of
+        # 'memtest', a small test scenario on a small iso to clone
+        my $openqa_url = get_var('OPENQA_HOST_URL', 'https://openqa.opensuse.org');
+        my $cmd = <<"EOF";
+last_tw_build=\$(/usr/share/openqa/script/client --host $openqa_url assets get | sed -n 's/^.*name.*Tumbleweed-NET-x86_64-Snapshot\\([0-9]\\+\\)-Media.*\$/\\1/p' | sort -n | tail -n 1)
+echo "Last Tumbleweed build on openqa.opensuse.org: \$last_tw_build"
+job_id=\$(/usr/share/openqa/script/client --host $openqa_url jobs get version=Tumbleweed scope=relevant arch=x86_64 build=\$last_tw_build flavor=NET | grep -B 8 'name.*memtest' | sed -n 's/^\\s*\\<id.*=> \\([0-9]\\+\\).*\$/\\1/p')
+echo "scenario x86_64-memtest-NET: \$job_id"
 sudo -u _openqa-worker touch /var/lib/openqa/factory/iso/.test || (echo "TODO: workaround, _openqa-worker should be able to write factory/iso" && mkdir -p /var/lib/openqa/factory/iso && chmod ugo+rwX /var/lib/openqa/factory/iso)
 ls -la /var/lib/openqa/factory/iso
-sudo -u _openqa-worker /usr/share/openqa/script/clone_job.pl --from https://openqa.opensuse.org $job_id
+sudo -u _openqa-worker /usr/share/openqa/script/clone_job.pl --from $openqa_url \$job_id
 EOF
         assert_script_run($_) foreach (split /\n/, $cmd);
     }

--- a/tests/osautoinst/start_test.pm
+++ b/tests/osautoinst/start_test.pm
@@ -4,7 +4,7 @@ use testapi;
 
 sub run {
     if (check_var('VERSION', '13.2')) {
-        validate_script_output '/usr/share/openqa/script/client isos post ISO=openSUSE-13.2-DVD-x86_64.iso DISTRI=opensuse VERSION=13.2 FLAVOR=DVD ARCH=x86_64 BUILD=0002', sub { m/1/ };
+        validate_script_output 'openqa-client isos post ISO=openSUSE-13.2-DVD-x86_64.iso DISTRI=opensuse VERSION=13.2 FLAVOR=DVD ARCH=x86_64 BUILD=0002', sub { m/1/ };
     }
     else {
         # please forgive the hackiness: using the openQA API but parsing the
@@ -12,9 +12,9 @@ sub run {
         # 'memtest', a small test scenario on a small iso to clone
         my $openqa_url = get_var('OPENQA_HOST_URL', 'https://openqa.opensuse.org');
         my $cmd = <<"EOF";
-last_tw_build=\$(/usr/share/openqa/script/client --host $openqa_url assets get | sed -n 's/^.*name.*Tumbleweed-NET-x86_64-Snapshot\\([0-9]\\+\\)-Media.*\$/\\1/p' | sort -n | tail -n 1)
+last_tw_build=\$(openqa-client --host $openqa_url assets get | sed -n 's/^.*name.*Tumbleweed-NET-x86_64-Snapshot\\([0-9]\\+\\)-Media.*\$/\\1/p' | sort -n | tail -n 1)
 echo "Last Tumbleweed build on openqa.opensuse.org: \$last_tw_build"
-job_id=\$(/usr/share/openqa/script/client --host $openqa_url jobs get version=Tumbleweed scope=relevant arch=x86_64 build=\$last_tw_build flavor=NET | grep -B 8 'name.*memtest' | sed -n 's/^\\s*\\<id.*=> \\([0-9]\\+\\).*\$/\\1/p')
+job_id=\$(openqa-client --host $openqa_url jobs get version=Tumbleweed scope=relevant arch=x86_64 build=\$last_tw_build flavor=NET | grep -B 8 'name.*memtest' | sed -n 's/^\\s*\\<id.*=> \\([0-9]\\+\\).*\$/\\1/p')
 echo "scenario x86_64-memtest-NET: \$job_id"
 sudo -u _openqa-worker touch /var/lib/openqa/factory/iso/.test || (echo "TODO: workaround, _openqa-worker should be able to write factory/iso" && mkdir -p /var/lib/openqa/factory/iso && chmod ugo+rwX /var/lib/openqa/factory/iso)
 ls -la /var/lib/openqa/factory/iso

--- a/tests/osautoinst/test_running.pm
+++ b/tests/osautoinst/test_running.pm
@@ -3,7 +3,7 @@ use base "openQAcoretest";
 use testapi;
 
 sub run {
-    validate_script_output "openqa-client jobs state=running", sub { m/"running"/ };
+    assert_script_run 'openqa-client jobs state=running | grep --color -z running';
     save_screenshot;
     type_string "clear\n";
 }

--- a/tests/osautoinst/test_running.pm
+++ b/tests/osautoinst/test_running.pm
@@ -3,9 +3,19 @@ use base "openQAcoretest";
 use testapi;
 
 sub run {
-    validate_script_output "/usr/share/openqa/script/client jobs state=running", sub { m/"running"/ };
+    validate_script_output "openqa-client jobs state=running", sub { m/"running"/ };
     save_screenshot;
     type_string "clear\n";
+}
+
+sub post_fail_hook {
+    assert_script_run 'openqa-client jobs';
+}
+
+sub test_flags {
+    # continue with other tests as we could use their information for
+    # debugging in case of failures.
+    return { important => 1 };
 }
 
 1;

--- a/tests/osautoinst/worker.pm
+++ b/tests/osautoinst/worker.pm
@@ -11,7 +11,7 @@ sub run {
     assert_screen 'password-prompt', 10;
     type_string $testapi::password . "\n";
     wait_still_screen(2);
-    validate_script_output 'systemctl status openqa-worker@1', sub { m/\Qactive (running)\E/ };
+    assert_script_run 'systemctl status openqa-worker@1 | grep --color -z "active (running)"';
     save_screenshot;
     type_string "clear\n";
 }


### PR DESCRIPTION
Make openqa host url configurable so that we can set it to an address that can
be reached also within openqa.opensuse.org domain.