### PR TITLE
Fix Dashboard Test

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -5,7 +5,7 @@ use Exporter;
 use strict;
 use testapi;
 
-our @EXPORT = qw/wait_for_desktop/;
+our @EXPORT = qw/wait_for_desktop ensure_unlocked_desktop/;
 
 sub wait_for_desktop {
     check_screen [qw/boot-menu openqa-desktop/];
@@ -24,6 +24,55 @@ sub wait_for_desktop {
         wait_still_screen(1);
         type_string $testapi::password . "\n";
         assert_screen 'openqa-desktop';
+    }
+}
+
+
+# if stay under tty console for long time, then check
+# screen lock is necessary when switch back to x11
+# all possible options should be handled within loop to get unlocked desktop
+sub ensure_unlocked_desktop {
+    my $counter = 10;
+    while ($counter--) {
+        assert_screen [qw(displaymanager displaymanager-password-prompt generic-desktop screenlock gnome-screenlock-password)], no_wait => 1;
+        if (match_has_tag 'displaymanager') {
+            if (check_var('DESKTOP', 'minimalx')) {
+                type_string "$username";
+                save_screenshot;
+            }
+            send_key 'ret';
+        }
+        if ((match_has_tag 'displaymanager-password-prompt') || (match_has_tag 'gnome-screenlock-password')) {
+            type_password;
+            send_key 'ret';
+        }
+        if (match_has_tag 'generic-desktop') {
+            send_key 'esc';
+            unless (get_var('DESKTOP', '') =~ m/minimalx|awesome|enlightenment|lxqt|mate/) {
+                # gnome might show the old 'generic desktop' screen although that is
+                # just a left over in the framebuffer but actually the screen is
+                # already locked so we have to try something else to check
+                # responsiveness.
+                # open run command prompt (if screen isn't locked)
+                mouse_hide(1);
+                send_key 'alt-f2';
+                if (check_screen 'desktop-runner') {
+                    send_key 'esc';
+                    assert_screen 'generic-desktop';
+                }
+                else {
+                    next;    # most probably screen is locked
+                }
+            }
+            last;            # desktop is unlocked, mission accomplished
+        }
+        if (match_has_tag 'screenlock') {
+            wait_screen_change {
+                send_key 'esc';    # end screenlock
+            };
+        }
+        wait_still_screen 2;       # slow down loop
+        die 'ensure_unlocked_desktop repeated too much. Check for X-server crash.' if ($counter eq 1);    # die loop when generic-desktop not matched
     }
 }
 

--- a/tests/openQA/dashboard.pm
+++ b/tests/openQA/dashboard.pm
@@ -5,7 +5,8 @@ use utils;
 
 sub run {
     send_key 'ctrl-alt-f7';
-    wait_for_desktop;
+    # wait_for_desktop;
+    ensure_unlocked_desktop();
     x11_start_program("firefox http://localhost", 60, { valid => 1 } );
     # starting from git might take a bit longer to get and generated assets
     assert_screen 'openqa-dashboard', check_var('OPENQA_FROM_GIT', 1) ? 180 : 60;


### PR DESCRIPTION
Replace wait_for_desktop with ensure_unlocked_desktop to check for case
when gnome shows desktop from framebuffer when its locked.
Added ensure_unlocked_desktop to openqa/lib/utils.pm from opensuse/lib/utils.pm for usage in this fix.

Ticket:
https://progress.opensuse.org/issues/19800
Verification:
http://10.160.65.204/tests/77
Needles:
https://github.com/os-autoinst/os-autoinst-needles-openQA/pull/9