### PR TITLE
Use install_minimalx test for PowerPC (version 2)

### DIFF
--- a/tests/osautoinst/start_test.pm
+++ b/tests/osautoinst/start_test.pm
@@ -8,14 +8,25 @@ sub run {
     }
     else {
         # please forgive the hackiness: using the openQA API but parsing the
-        # human-readable output of 'client' to get the most recent job of
-        # 'memtest', a small test scenario on a small iso to clone
+        # human-readable output of 'client' to get the most recent job
+        my $arch = get_var('ARCH');
+        my $ttest;
+        my $range;
+        if ($arch eq 'ppc64le') {
+           $ttest = 'install_minimalx';
+           $range = 120;
+        }
+        else {
+           # 'memtest', a small test scenario on a small iso to clone
+           $ttest = 'memtest';
+           $range = 10;
+        }
         my $openqa_url = get_var('OPENQA_HOST_URL', 'https://openqa.opensuse.org');
         my $cmd = <<"EOF";
-last_tw_build=\$(openqa-client --host $openqa_url assets get | sed -n 's/^.*name.*Tumbleweed-NET-x86_64-Snapshot\\([0-9]\\+\\)-Media.*\$/\\1/p' | sort -n | tail -n 1)
+last_tw_build=\$(openqa-client --host $openqa_url assets get | sed -n 's/^.*name.*Tumbleweed-NET-$arch-Snapshot\\([0-9]\\+\\)-Media.*\$/\\1/p' | sort -n | tail -n 1)
 echo "Last Tumbleweed build on openqa.opensuse.org: \$last_tw_build"
-job_id=\$(openqa-client --host $openqa_url jobs get version=Tumbleweed scope=relevant arch=x86_64 build=\$last_tw_build flavor=NET | grep -B 8 'name.*memtest' | sed -n 's/^\\s*\\<id.*=> \\([0-9]\\+\\).*\$/\\1/p')
-echo "scenario x86_64-memtest-NET: \$job_id"
+job_id=\$(openqa-client --host $openqa_url jobs get version=Tumbleweed scope=relevant arch=$arch build=\$last_tw_build flavor=NET | grep -B $range 'name.*$ttest' | grep -A $range group_id | sed -n 's/^\\s*\\<id.*=> \\([0-9]\\+\\).*\$/\\1/p')
+echo "scenario $arch-$ttest-NET: \$job_id"
 sudo -u _openqa-worker touch /var/lib/openqa/factory/iso/.test || (echo "TODO: workaround, _openqa-worker should be able to write factory/iso" && mkdir -p /var/lib/openqa/factory/iso && chmod ugo+rwX /var/lib/openqa/factory/iso)
 ls -la /var/lib/openqa/factory/iso
 echo "Prevent bsc#1027347"


### PR DESCRIPTION
because there is no memtest for this architecture.

Signed-off-by: Michel Normand <normand@linux.vnet.ibm.com>

patch validated in my openqa local instance with ppc64le (I do not have x86_64)
related video at https://michelmno.fedorapeople.org/tmp3/video.ogv