### PR TITLE
Only retrieve last job if more than one reported

### DIFF
--- a/tests/osautoinst/start_test.pm
+++ b/tests/osautoinst/start_test.pm
@@ -25,7 +25,7 @@ sub run {
         my $cmd = <<"EOF";
 last_tw_build=\$(openqa-client --host $openqa_url assets get | sed -n 's/^.*name.*Tumbleweed-NET-$arch-Snapshot\\([0-9]\\+\\)-Media.*\$/\\1/p' | sort -n | tail -n 1)
 echo "Last Tumbleweed build on openqa.opensuse.org: \$last_tw_build"
-job_id=\$(openqa-client --host $openqa_url jobs get version=Tumbleweed scope=relevant arch=$arch build=\$last_tw_build flavor=NET | grep -B $range 'name.*$ttest' | grep -A $range group_id | sed -n 's/^\\s*\\<id.*=> \\([0-9]\\+\\).*\$/\\1/p')
+job_id=\$(openqa-client --host $openqa_url jobs get version=Tumbleweed scope=relevant arch=$arch build=\$last_tw_build flavor=NET | grep -B $range 'name.*$ttest' | grep -A $range group_id | sed -n 's/^\\s*\\<id.*=> \\([0-9]\\+\\).*\$/\\1/p' | sort -n | tail -n 1)
 echo "scenario $arch-$ttest-NET: \$job_id"
 sudo -u _openqa-worker touch /var/lib/openqa/factory/iso/.test || (echo "TODO: workaround, _openqa-worker should be able to write factory/iso" && mkdir -p /var/lib/openqa/factory/iso && chmod ugo+rwX /var/lib/openqa/factory/iso)
 ls -la /var/lib/openqa/factory/iso


### PR DESCRIPTION
This is required to handle specific condition
where a job has been manually restarted.

Signed-off-by: Michel Normand <normand@linux.vnet.ibm.com>