### PR TITLE
Add workaround for Dashboard Test

### DIFF
--- a/tests/openQA/dashboard.pm
+++ b/tests/openQA/dashboard.pm
@@ -9,7 +9,11 @@ sub run {
     ensure_unlocked_desktop();
     x11_start_program("firefox http://localhost", 60, { valid => 1 } );
     # starting from git might take a bit longer to get and generated assets
-    assert_screen 'openqa-dashboard', check_var('OPENQA_FROM_GIT', 1) ? 180 : 60;
+    # workaround for poo#19798, basically doubles the timeout
+    if ((check_screen 'openqa-dashboard', 180) == undef) {
+        record_soft_failure 'ff took to long to start';
+    }
+    #wait few minutes for ff to start and then fail the test
+    assert_screen 'openqa-dashboard', 360;
 }
-
 1;


### PR DESCRIPTION
Implemented a workaround for poo#19798 where
Firefox takes too long to start in the dashboard
test and it then fails.
    
Now waits 180 seconds, records a soft_failure
if ff did not start and then waits another
360 seconds

Verification:
http://pinky.arch.suse.de/tests/40#

Issues:
https://progress.opensuse.org/issues/19798