### PR TITLE
Revert dashboard.pm to original state

### DIFF
--- a/tests/openQA/dashboard.pm
+++ b/tests/openQA/dashboard.pm
@@ -9,11 +9,6 @@ sub run {
     ensure_unlocked_desktop();
     x11_start_program("firefox http://localhost", 60, { valid => 1 } );
     # starting from git might take a bit longer to get and generated assets
-    # workaround for poo#19798, basically doubles the timeout
-    if ((check_screen 'openqa-dashboard', 180) == undef) {
-        record_soft_failure 'ff took to long to start';
-    }
-    #wait few minutes for ff to start and then fail the test
-    assert_screen 'openqa-dashboard', 360;
+    assert_screen 'openqa-dashboard', check_var('OPENQA_FROM_GIT',1) ? 180 : 60;
 }
 1;


### PR DESCRIPTION
Improved and simplified code.
Readded dropped check for OPENQA_FROM_GIT to keep distinction

Verification run:
http://pinky.arch.suse.de/tests/53#

PR#27:
https://github.com/os-autoinst/os-autoinst-distri-openQA/pull/27