### PR TITLE
Fix ruby dependency issue in openqa_webui

### DIFF
--- a/tests/install/openqa_webui.pm
+++ b/tests/install/openqa_webui.pm
@@ -66,7 +66,7 @@ sub install_from_git {
     my $configure = <<'EOF';
 echo "I am not sure about the next line but Santi told me - imagine a venezualean accent - you want this"
 zypper --non-interactive in -t pattern devel_basis devel_ruby devel_perl devel_python devel_C_C++
-zypper --non-interactive in git-core
+zypper --non-interactive in git-core ruby-devel
 git clone https://github.com/os-autoinst/openQA.git
 curl -L https://raw.githubusercontent.com/miyagawa/cpanminus/master/cpanm | perl - App::cpanminus
 cpanm local::lib


### PR DESCRIPTION
Fixed poo#20494 where the openqa_webui test would fail due to
unmet dependencies by installing ruby-devel

Requires TW-build >= 20170724

Issue:
https://progress.opensuse.org/issues/20494

Verification run:
http://pinky.arch.suse.de/tests/228#
(don't be confused by the test name, the TW image is 724, not 720)