### PR TITLE
Fix test_running by trying up to five times

### DIFF
--- a/tests/osautoinst/test_running.pm
+++ b/tests/osautoinst/test_running.pm
@@ -3,7 +3,7 @@ use base "openQAcoretest";
 use testapi;
 
 sub run {
-    assert_script_run 'openqa-client jobs state=running | grep --color -z running';
+    assert_script_run ' ret=false; for i in {1..5} ; do openqa-client jobs state=running | grep --color -z running && ret=true && break ; sleep 30 ; done ; [ "$ret" = "true" ] ; echo $? ' ,300;
     save_screenshot;
     type_string "clear\n";
 }


### PR DESCRIPTION
Fixed test running by looking up to five times with a waiting time
of 30 seconds between each try
Necessary due to slow starting test used in start_test

Verification runs:
[1](http://10.160.65.204/tests/494)
[2](http://10.160.65.204/tests/498)
