### PR TITLE
Revert "Add aarch64 support and fix test from git"

### DIFF
--- a/tests/install/openqa_webui.pm
+++ b/tests/install/openqa_webui.pm
@@ -8,13 +8,15 @@ sub install_from_repos {
     diag('following https://github.com/os-autoinst/openQA/blob/master/docs/Installing.asciidoc');
     my $add_repo;
     if (get_required_var('VERSION') =~ /(tw|Tumbleweed)/) {
-        my %repo_suffix = (
-            x86_64 => 'Tumbleweed',
-            aarch64 => 'Factory_ARM',
-            ppc64le => 'Factory_PowerPC'
-        );
-        my $repo = 'openSUSE_' . $repo_suffix{get_required_var('ARCH')};
-        $add_repo = "zypper --non-interactive ar -f obs://devel:openQA/$repo openQA";
+        if (check_var('ARCH', 'ppc64le')) {
+            $add_repo = <<'EOF';
+zypper --non-interactive ar -f obs://devel:openQA/openSUSE_Factory_PowerPC openQA
+EOF
+        }
+        else {
+            $add_repo = <<'EOF';
+zypper --non-interactive ar -f obs://devel:openQA/openSUSE_Tumbleweed openQA
+EOF
         }
     }
     elsif (check_var('VERSION', '42.1')) {
@@ -70,7 +72,7 @@ git clone https://github.com/os-autoinst/openQA.git
 cd openQA
 for p in $(cpanfile-dump); do echo -n "perl($p) "; done | xargs zypper --non-interactive in -C
 cpanm -nq --installdeps .
-for i in headers proxy proxy_http proxy_wstunnel rewrite ; do a2enmod $i ; done
+for i in headers proxy proxy_http proxy_wstunnel ; do a2enmod $i ; done
 cp etc/apache2/vhosts.d/openqa-common.inc /etc/apache2/vhosts.d/
 sed "s/#ServerName.*$/ServerName $(hostname)/" etc/apache2/vhosts.d/openqa.conf.template > /etc/apache2/vhosts.d/openqa.conf
 systemctl restart apache2 || systemctl status --no-pager apache2


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-openQA#37

Broke the tests with

```
"my" variable $configure masks earlier declaration in same scope at /var/lib/openqa/cache/openqa1-opensuse/tests/openqa//tests/install/openqa_webui.pm line 64.
[2018-10-13T16:13:28.0913 CEST] [debug] error on /tests/install/openqa_webui.pm: syntax error at /var/lib/openqa/cache/openqa1-opensuse/tests/openqa//tests/install/openqa_webui.pm line 20, near "elsif"
Global symbol "$add_repo" requires explicit package name (did you forget to declare "my $add_repo"?) at /var/lib/openqa/cache/openqa1-opensuse/tests/openqa//tests/install/openqa_webui.pm line 21.
```