### PR TITLE
Fix switch to text terminal for more recent GDM

### DIFF
--- a/tests/install/openqa_webui.pm
+++ b/tests/install/openqa_webui.pm
@@ -82,7 +82,7 @@ EOF
 }
 
 sub run {
-    send_key "ctrl-alt-f2";
+    send_key "ctrl-alt-f3";
     assert_screen "inst-console";
     type_string "root\n";
     assert_screen "password-prompt";


### PR DESCRIPTION
See https://openqa.opensuse.org/tests/962686#step/openqa_webui/2

Verification run: https://openqa.opensuse.org/tests/962831