### PR TITLE
Use a 'URL' variable that has no special meaning in openQA

### DIFF
--- a/tests/osautoinst/start_test.pm
+++ b/tests/osautoinst/start_test.pm
@@ -7,7 +7,7 @@ sub run {
     # human-readable output of 'client' to get the most recent job
     my $arch       = get_var('ARCH');
     my $ttest      = 'minimalx';
-    my $openqa_url = get_var('OPENQA_HOST_URL', 'https://openqa.opensuse.org');
+    my $openqa_url = get_var('OPENQA_HOST', 'https://openqa.opensuse.org');
     my $cmd        = <<"EOF";
 last_tw_build=\$(openqa-client --host $openqa_url assets get | sed -n 's/^.*name.*Tumbleweed-NET-$arch-Snapshot\\([0-9]\\+\\)-Media.*\$/\\1/p' | sort -n | tail -n 1)
 echo "Last Tumbleweed build on openqa.opensuse.org: \$last_tw_build"


### PR DESCRIPTION
Any variable with the suffix "_URL" is understood as an asset by openQA
but as "OPENQA_HOST_URL" is not really anything like an openQA asset
then openQA logs a warning "Unable to get filename from
http://openqa.opensuse.org" which we can prevent.

Related progress issue: https://progress.opensuse.org/issues/53399