### PR TITLE
Fix false positive matches when checking for running job

### DIFF
--- a/tests/osautoinst/test_running.pm
+++ b/tests/osautoinst/test_running.pm
@@ -3,7 +3,8 @@ use base "openQAcoretest";
 use testapi;
 
 sub run {
-    assert_script_run ' ret=false; for i in {1..5} ; do openqa-client jobs state=running | grep --color -z running && ret=true && break ; sleep 30 ; done ; [ "$ret" = "true" ] ; echo $? ', 300;
+    assert_script_run 'command -v ack >/dev/null || zypper --no-refresh -n in ack';
+    assert_script_run 'ret=false; for i in {1..5} ; do openqa-client jobs state=running | ack --passthru --color running && ret=true && break ; sleep 30 ; done ; [ "$ret" = "true" ]', 300;
     save_screenshot;
     type_string "clear\n";
 }

--- a/tests/osautoinst/test_running.pm
+++ b/tests/osautoinst/test_running.pm
@@ -13,7 +13,7 @@ sub post_fail_hook {
     $self->SUPER::post_fail_hook;
     script_run 'lsmod | grep kvm';
     save_screenshot;
-    $self->get_log('grep --color -z -E "(vmx|svm)" /proc/cpuinfo' => 'cpuinfo');
+    get_log('grep --color -z -E "(vmx|svm)" /proc/cpuinfo' => 'cpuinfo');
     assert_script_run 'grep --color -z -E "(vmx|svm)" /proc/cpuinfo', fail_message => 'Machine does not support nested virtualization, please enable in worker host';
 }
 


### PR DESCRIPTION
Echoing the exit code was erroneously evaluated as always true within
`assert_script_run` call causing false positives in case the client
could not get a running job from the openQA server.

This commit changes "grep" to "ack" to show the output regardless of a
grep-match.

Related progress issue: https://progress.opensuse.org/issues/58007