### PR TITLE
Retry zypper installation

### DIFF
--- a/tests/install/test_distribution.pm
+++ b/tests/install/test_distribution.pm
@@ -9,7 +9,24 @@ sub run {
     diag('initialize working copy of openSUSE tests distribution with correct user');
     assert_script_run('username=bernhard email=bernhard@susetest /usr/share/openqa/script/fetchneedles', 3600);
     save_screenshot;
-    assert_script_run('zypper --no-refresh -n in os-autoinst-distri-opensuse-deps', 600);
+
+    # 104 is the zypper exit code if a package cannot be found
+    my $cmd = <<'EOM';
+(
+    for i in {1..7}
+    do
+        zypper --non-interactive install os-autoinst-distri-opensuse-deps && exit 0
+        rc=$?
+        (( $rc == 104 )) || break
+    done
+    exit $rc
+)
+EOM
+    chomp $cmd;
+    my $ret = assert_script_run(
+        $cmd,
+        timeout => 600,
+    );
     type_string "clear\n";
     # prepare for next test
     type_string "logout\n";


### PR DESCRIPTION
Currently the installation can fail if the package is modified
during the command.

Issue: https://progress.opensuse.org/issues/60008
Test runs: https://openqa.opensuse.org/tests/1089700,  https://openqa.opensuse.org/tests/1089720, https://openqa.opensuse.org/tests/1089772

I verified that the exit code is 104 for `zypper install non-existant-package`. However, I'm not sure how to reproduce the actual error, so I don't know yet if the exit code will also be 104 there.