### PR TITLE
Remove --no-refresh from zypper call

### DIFF
--- a/tests/install/test_distribution.pm
+++ b/tests/install/test_distribution.pm
@@ -9,7 +9,7 @@ sub run {
     diag('initialize working copy of openSUSE tests distribution with correct user');
     assert_script_run('username=bernhard email=bernhard@susetest /usr/share/openqa/script/fetchneedles', 3600);
     save_screenshot;
-    assert_script_run('zypper --no-refresh -n in os-autoinst-distri-opensuse-deps', 600);
+    assert_script_run('zypper -n in os-autoinst-distri-opensuse-deps', 600);
     type_string "clear\n";
     # prepare for next test
     type_string "logout\n";


### PR DESCRIPTION
Currently the install might fail if the package was updated in the meantime.

Issue: https://progress.opensuse.org/issues/60008
Test run: https://openqa.opensuse.org/tests/1090694

See also: https://github.com/openSUSE/zypper/issues/312
