### PR TITLE
Force a zypper refresh before installing

### DIFF
--- a/tests/install/test_distribution.pm
+++ b/tests/install/test_distribution.pm
@@ -9,6 +9,7 @@ sub run {
     diag('initialize working copy of openSUSE tests distribution with correct user');
     assert_script_run('username=bernhard email=bernhard@susetest /usr/share/openqa/script/fetchneedles', 3600);
     save_screenshot;
+    assert_script_run('zypper -n ref -f', 60);
     assert_script_run('zypper -n in os-autoinst-distri-opensuse-deps', 600);
     type_string "clear\n";
     # prepare for next test


### PR DESCRIPTION
Currently the install might fail if the package was updated in the meantime,
and the automatic refresh isn't always done because of the refresh.delay

Issue: https://progress.opensuse.org/issues/60008
See also: https://github.com/openSUSE/zypper/issues/312, https://github.com/os-autoinst/os-autoinst-distri-openQA/pull/54

Test run: https://openqa.opensuse.org/tests/1097223