### PR TITLE
Remove obsolete code from susedistribution fixing missing "wait_idle" as well

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -3,13 +3,7 @@ use base 'distribution';
 
 # Base class for all test modules
 
-use testapi qw(send_key %cmd assert_screen check_screen check_var get_var save_screenshot type_password type_string wait_idle wait_serial mouse_hide);
-
-sub init {
-    my ($self) = @_;
-
-    $self->SUPER::init();
-}
+use testapi qw(send_key assert_screen check_screen save_screenshot type_string mouse_hide);
 
 sub x11_start_program {
     my ($self, $program, $timeout, $options) = @_;
@@ -30,80 +24,6 @@ sub x11_start_program {
             send_key 'ret';
         }
     }
-}
-
-# this needs to move to the distribution
-sub ensure_installed {
-    my ($self, @pkglist) = @_;
-    my $timeout;
-    if ($pkglist[-1] =~ /^[0-9]+$/) {
-        $timeout = $pkglist[-1];
-        pop @pkglist;
-    }
-    else {
-        $timeout = 80;
-    }
-
-    testapi::x11_start_program("xterm");
-    assert_screen('xterm-started');
-    type_string("pkcon install @pkglist\n");
-    my @tags = qw/Policykit Policykit-behind-window PolicyKit-retry pkcon-proceed-prompt pkcon-succeeded/;
-    while (1) {
-        my $ret = assert_screen(\@tags, $timeout);
-        if ($ret->{needle}->has_tag('Policykit') ||
-            $ret->{needle}->has_tag('PolicyKit-retry')) {
-            type_password;
-            send_key("ret", 1);
-            @tags = grep { $_ ne 'Policykit' } @tags;
-            @tags = grep { $_ ne 'Policykit-behind-window' } @tags;
-            if ($ret->{needle}->has_tag('PolicyKit-retry')) {
-                # Only a single retry is acceptable
-                @tags = grep { $_ ne 'PolicyKit-retry' } @tags;
-            }
-            next;
-        }
-        if ($ret->{needle}->has_tag('Policykit-behind-window')) {
-            send_key("alt-tab");
-            sleep 3;
-            next;
-        }
-        if ($ret->{needle}->has_tag('pkcon-proceed-prompt')) {
-            send_key("y");
-            send_key("ret");
-            @tags = grep { $_ ne 'pkcon-proceed-prompt' } @tags;
-            next;
-        }
-        if ($ret->{needle}->has_tag('pkcon-succeeded')) {
-            send_key("alt-f4");    # close xterm
-            return;
-        }
-    }
-
-    if ($password) { type_password; send_key("ret", 1); }
-    wait_still_screen(7, 90);      # wait for install
-}
-
-sub script_sudo {
-    my ($self, $prog, $wait) = @_;
-
-    type_string "clear\n";
-    type_string "su -c '$prog'\n";
-    if (!get_var("LIVETEST")) {
-        assert_screen 'password-prompt';
-        type_password;
-        send_key "ret";
-    }
-    wait_idle $wait;
-}
-
-sub become_root {
-    my ($self) = @_;
-
-    $self->script_sudo('bash', 1);
-    type_string "whoami > /dev/$testapi::serialdev\n";
-    wait_serial("root", 2) || die "Root prompt not there";
-    type_string "cd /tmp\n";
-    type_string "clear\n";
 }
 
 1;


### PR DESCRIPTION
os-autoinst removed "wait_idle" which was deprecated for a long time.
Along with this we can remove all the outdated and unused code from
susedistribution that is old copy-paste content from
os-autoinst-distri-opensuse anyway.