### PR TITLE
Get the basename of HDD before splitting

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -4,11 +4,12 @@ use base Exporter;
 use Exporter;
 use strict;
 use testapi;
+use File::Basename qw(basename);
 
 our @EXPORT = qw(switch_to_x11 wait_for_desktop ensure_unlocked_desktop);
 
 sub switch_to_x11 {
-    my @hdd = split(/-/, get_required_var('HDD_1'));
+    my @hdd = split(/-/, basename get_required_var('HDD_1'));
     # older openSUSE Tumbleweed has x11 still on tty7
     my $x11_tty = $hdd[3] < 20190617 ? 'f7' : 'f2';
     send_key "ctrl-alt-$x11_tty";


### PR DESCRIPTION
A dash in the fullpath can get wrong results

Test run: https://openqa.opensuse.org/tests/1143729