### PR TITLE
Add openQA_webui container test

### DIFF
--- a/main.pm
+++ b/main.pm
@@ -40,14 +40,22 @@ sub load_osautoinst_tests() {
 }
 
 sub load_openQA_tests() {
-    loadtest "openQA/dashboard.pm";
-    loadtest "openQA/login.pm";
-    return 1 if get_var('INSTALL_ONLY');
-    loadtest "openQA/build_results.pm";
-    loadtest "openQA/test_live.pm";
-    loadtest "openQA/test_results.pm";
-    loadtest "openQA/tests.pm";
-    loadtest "openQA/admin.pm";
+    if (get_var("OPENQA_CONTAINERS")) {
+      loadtest "containers/build.pm";
+      loadtest "containers/setup_env.pm";
+      loadtest "containers/multiple_container_webui.pm";
+      loadtest "containers/single_container_webui.pm";
+    }
+    else {
+      loadtest "openQA/dashboard.pm";
+      loadtest "openQA/login.pm";
+      return 1 if get_var('INSTALL_ONLY');
+      loadtest "openQA/build_results.pm";
+      loadtest "openQA/test_live.pm";
+      loadtest "openQA/test_results.pm";
+      loadtest "openQA/tests.pm";
+      loadtest "openQA/admin.pm";
+    }
 }
 
 sub load_shutdown() {

--- a/tests/containers/build.pm
+++ b/tests/containers/build.pm
@@ -1,0 +1,13 @@
+use strict;
+use base "openQAcoretest";
+use testapi;
+
+sub run {
+    my ($self) = @_;
+    assert_script_run("git clone https://github.com/os-autoinst/openQA.git", timeout => 300);
+    assert_script_run("docker build openQA/container/webui -t openqa_webui", timeout => 600);
+    assert_script_run("docker build openQA/container/worker -t openqa_worker", timeout => 600);
+    assert_script_run("docker build openQA/container/openqa_data -t openqa_data", timeout => 600);
+}
+
+1;

--- a/tests/containers/multiple_container_webui.pm
+++ b/tests/containers/multiple_container_webui.pm
@@ -1,0 +1,33 @@
+use Mojo::Base qw(openQAcoretest);
+use testapi;
+use utils;
+
+sub test_component {
+   my ($name, $port, $volumes) = @_;
+   assert_script_run("docker run --rm -d --network testing -e MODE=$name -e MOJO_LISTEN=http://0.0.0.0:$port $volumes -p $port:$port --name $name openqa_webui");
+   wait_for_container_log($name, "Listening", "docker");
+   assert_script_run("docker logs $name");
+   assert_script_run("docker exec $name curl localhost:$port >/dev/null");
+   record_info("$name working");
+}
+
+sub run {
+   my ($self) = @_;
+   my $volumes = "-v \"/root/data/factory:/data/factory\" -v \"/root/data/tests:/data/tests\" -v \"/root/openQA/container/webui/conf:/data/conf:ro\"";
+
+   test_component("webui", 9526, $volumes);
+   test_component("websockets", 9527, $volumes);
+   test_component("livehandler", 9528, $volumes);
+   test_component("scheduler", 9529, $volumes);
+
+   assert_script_run("docker run -d --network testing -e MODE=gru $volumes --name gru openqa_webui");
+   wait_for_container_log("gru", "started", "docker");
+
+   assert_script_run("docker rm -f webui");
+   assert_script_run("docker rm -f websockets");
+   assert_script_run("docker rm -f livehandler");
+   assert_script_run("docker rm -f scheduler");
+   assert_script_run("docker rm -f gru");
+}
+
+1;

--- a/tests/containers/setup_env.pm
+++ b/tests/containers/setup_env.pm
@@ -1,0 +1,14 @@
+use Mojo::Base qw(openQAcoretest);
+use testapi;
+use utils;
+
+sub run {
+   my ($self) = @_;
+
+   assert_script_run("mkdir -p /root/data/factory/{iso,hdd,other} /root/data/tests");
+   assert_script_run("docker network create testing");
+   assert_script_run("docker run --rm -d --network testing -e POSTGRES_PASSWORD=openqa -e POSTGRES_USER=openqa -e POSTGRES_DB=openqa --net-alias=db --name db postgres", timeout => 600);
+   wait_for_container_log("db", "database system is ready to accept connections", "docker");
+}
+
+1;

--- a/tests/containers/single_container_webui.pm
+++ b/tests/containers/single_container_webui.pm
@@ -1,0 +1,19 @@
+use Mojo::Base qw(openQAcoretest);
+use testapi;
+use utils;
+
+sub run {
+  my ($self) = @_;
+  my $volumes = "-v \"/root/data/factory:/data/factory\" -v \"/root/data/tests:/data/tests\" -v \"/root/openQA/container/webui/conf:/data/conf:ro\"";
+  my $certificates = "-v \"/root/server.crt:/etc/apache2/ssl.crt/server.crt\" -v \"/root/server.crt:/etc/apache2/ssl.crt/ca.crt\" -v \"/root/server.key:/etc/apache2/ssl.key/server.key\"";
+
+  assert_script_run("openssl req -newkey rsa:4096 -x509 -sha256 -days 365 -nodes -subj '/CN=www.mydom.com/O=My Company Name LTD./C=DE' -out server.crt -keyout server.key");
+
+  assert_script_run("docker run --rm -d --network testing $volumes $certificates -p 80:80 --name openqa_webui openqa_webui");
+  wait_for_container_log("openqa_webui", "Web application available at", "docker");
+
+  assert_script_run("curl http://localhost");
+  assert_script_run("docker rm -f openqa_webui");
+}
+
+1;

--- a/tests/install/openqa_webui.pm
+++ b/tests/install/openqa_webui.pm
@@ -68,6 +68,11 @@ EOF
     assert_script_run('while ! [ -f nohup.out ]; do sleep 1 ; done && grep -qP "Listening at.*(127.0.0.1|localhost)" <(tail -f -n0 nohup.out) ', 600);
 }
 
+sub install_containers {
+    assert_script_run("zypper --non-interactive install docker git", timeout => 300);
+    assert_script_run("systemctl start docker");
+}
+
 sub run {
     send_key "ctrl-alt-f3";
     assert_screen "inst-console";
@@ -78,7 +83,12 @@ sub run {
     diag('Ensure packagekit is not interfering with zypper calls');
     script_run('systemctl stop packagekit.service; systemctl mask packagekit.service');
     if (check_var('OPENQA_FROM_GIT', 1)) {
-        install_from_git;
+        if (get_var('OPENQA_CONTAINERS')) {
+            install_containers;
+        }
+        else {
+            install_from_git;
+        }
     }
     else {
         install_from_repos;


### PR DESCRIPTION
Test to build and test openQA_webui.

The test has 4 parts:
- Install git and docker
- Prepare the data directories and launch the DB container
- Run the webui splited in components in multiple containers and tries to connect to everyone
- Run the webui in a single container (apache) and tries to connect to the default port 80

https://progress.opensuse.org/issues/80520
