### PR TITLE
containers: add more verbose when a container doesn't work well

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -97,6 +97,8 @@ sub wait_for_container_log {
         last if ($timeout == 0);
     }
 
+    system("$cmd logs $container") if ($timeout == 0);
+
     assert_script_run("$cmd logs $container 2>&1 | grep \"$text\" >/dev/null");
 }
 


### PR DESCRIPTION
Problem: When a container doesn't work as expected and the function
wait_for_container_log fails with a timeout, we don't have logs to
analyze

Solution: On case of timeout the logs are displayed

Related to https://progress.opensuse.org/issues/88754