### PR TITLE
Retry when a container build fails

### DIFF
--- a/tests/containers/build.pm
+++ b/tests/containers/build.pm
@@ -5,9 +5,9 @@ use testapi;
 sub run {
     my ($self) = @_;
     assert_script_run("git clone https://github.com/os-autoinst/openQA.git", timeout => 300);
-    assert_script_run("docker build openQA/container/webui -t openqa_webui", timeout => 600);
-    assert_script_run("docker build openQA/container/worker -t openqa_worker", timeout => 600);
-    assert_script_run("docker build openQA/container/openqa_data -t openqa_data", timeout => 600);
+    assert_script_run('for i in {1..3}; do docker build openQA/container/webui -t openqa_webui && break; done', timeout => 600);
+    assert_script_run('for i in {1..3}; do docker build openQA/container/worker -t openqa_worker && break; done', timeout => 600);
+    assert_script_run('for i in {1..3}; do docker build openQA/container/openqa_data -t openqa_data && break; done', timeout => 600);
 }
 
 1;


### PR DESCRIPTION
Eventually some tests during the build of container images fail in
during the installation of packages.

See: openqa.opensuse.org/tests/1700287#step/build/5

This commit uses an alternative method to run the scripts to retry
in case of failure up to 3 times

https://progress.opensuse.org/issues/88754