### PR TITLE
containers: Show openqa_webui logs to ensure a correct investigation

### DIFF
--- a/tests/containers/single_container_webui.pm
+++ b/tests/containers/single_container_webui.pm
@@ -9,11 +9,16 @@ sub run {
 
   assert_script_run("openssl req -newkey rsa:4096 -x509 -sha256 -days 365 -nodes -subj '/CN=www.mydom.com/O=My Company Name LTD./C=DE' -out server.crt -keyout server.key");
 
-  assert_script_run("docker run --rm -d --network testing $volumes $certificates -p 80:80 --name openqa_webui openqa_webui");
+  assert_script_run("docker run -d --network testing $volumes $certificates -p 80:80 --name openqa_webui openqa_webui");
   wait_for_container_log("openqa_webui", "Web application available at", "docker");
 
   assert_script_run("curl http://localhost");
   assert_script_run("docker rm -f openqa_webui");
+}
+
+sub post_fail_hook {
+  script_run("docker logs openqa_webui");
+  script_run("docker rm -f openqa_webui");
 }
 
 1;


### PR DESCRIPTION
Openqa test "single_container_webui" eventually fails but we don't have information
about what happened because the logs are removed when the container is removed

Removing -rm ensures that we have the logs although it fails

https://progress.opensuse.org/issues/91488