### PR TITLE
Bump package installation timeout for "docker git" due to slow install

### DIFF
--- a/tests/install/openqa_webui.pm
+++ b/tests/install/openqa_webui.pm
@@ -69,7 +69,7 @@ EOF
 }
 
 sub install_containers {
-    assert_script_run("zypper --non-interactive install docker git", timeout => 300);
+    assert_script_run("zypper --non-interactive install docker git", timeout => 600);
     assert_script_run("systemctl start docker");
 }
 


### PR DESCRIPTION
As seen recently in
https://openqa.opensuse.org/tests/1778520#step/openqa_webui/6
package downloads and installations can timeout, likely due to
performance degradations in the infrastructure. Also, the list of
package dependencies that are installed along with docker and git can be
heavy including regeneration of initrd images hence it makes sense to
bump the timeout for this specific installation call.

Related progress issue: https://progress.opensuse.org/issues/93826