### PR TITLE
containers: Increase the timeout to build

### DIFF
--- a/tests/containers/build.pm
+++ b/tests/containers/build.pm
@@ -5,9 +5,9 @@ use testapi;
 sub run {
     my ($self) = @_;
     assert_script_run("git clone https://github.com/os-autoinst/openQA.git", timeout => 300);
-    assert_script_run('for i in {1..3}; do docker build openQA/container/webui -t openqa_webui && break; done', timeout => 600);
-    assert_script_run('for i in {1..3}; do docker build openQA/container/worker -t openqa_worker && break; done', timeout => 600);
-    assert_script_run('for i in {1..3}; do docker build openQA/container/openqa_data -t openqa_data && break; done', timeout => 600);
+    assert_script_run('for i in {1..3}; do docker build openQA/container/webui -t openqa_webui && break; done', timeout => 1000);
+    assert_script_run('for i in {1..3}; do docker build openQA/container/worker -t openqa_worker && break; done', timeout => 1000);
+    assert_script_run('for i in {1..3}; do docker build openQA/container/openqa_data -t openqa_data && break; done', timeout => 1000);
 }
 
 1;


### PR DESCRIPTION
Eventually the containers test fail in the building process.
This process spend a lot of time downloading and installing
the required packages.

This PR increases the timeout of these builds

https://progress.opensuse.org/issues/93713