### PR TITLE
[WIP] containers: pre-create the working directories with a=rwx permissions 

### DIFF
--- a/tests/containers/single_container_webui.pm
+++ b/tests/containers/single_container_webui.pm
@@ -6,7 +6,8 @@ sub run {
   my ($self) = @_;
   my $volumes = '-v "/root/data/factory:/data/factory" -v "/root/data/tests:/data/tests" -v "/root/openQA/container/webui/conf:/data/conf:ro"';
   my $certificates = '-v "/root/server.crt:/etc/apache2/ssl.crt/server.crt" -v "/root/server.crt:/etc/apache2/ssl.crt/ca.crt" -v "/root/server.key:/etc/apache2/ssl.key/server.key"';
-
+  
+  assert_script_run("mkdir -p -m a=rwx /root/data/{factory,tests}");
   assert_script_run("openssl req -newkey rsa:4096 -x509 -sha256 -days 365 -nodes -subj '/CN=www.mydom.com/O=My Company Name LTD./C=DE' -out server.crt -keyout server.key");
 
   assert_script_run("docker run -d --network testing $volumes $certificates -p 80:80 --name openqa_webui openqa_webui");


### PR DESCRIPTION
We found that eventually the test single_container_webui fails because the webui
cannot create the needed directories in /root/data/factory

With this commit we ensure to create the directories with the correct permissions
before launch the container

Testing: https://openqa.opensuse.org/tests/1840015

https://progress.opensuse.org/issues/95179