### PR TITLE
[WIP] Replace send_key by send_key_until_needlematch to change to the console

### DIFF
--- a/tests/install/openqa_webui.pm
+++ b/tests/install/openqa_webui.pm
@@ -75,7 +75,7 @@ sub install_containers {
 
 sub run {
     send_key "ctrl-alt-f3";
-    assert_screen "inst-console";
+    assert_screen("inst-console", timeout => 60);
     type_string "root\n";
     assert_screen "password-prompt";
     type_string $testapi::password . "\n";


### PR DESCRIPTION
Sometimes send_key is not enough to force the change to the console failing
the console needle check.

https://progress.opensuse.org/issues/95721