### PR TITLE
Add script to install additional dependencies of the test distribution

### DIFF
--- a/install_deps.sh
+++ b/install_deps.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+zypper -n --gpg-auto-import-keys install perl-Inline-Python


### PR DESCRIPTION
This script will automatically be called when starting an openQA worker in
our containerized setup. We already have such a script in the openSUSE test
distribution.