### PR TITLE
Also check for 'done' jobs

### DIFF
--- a/tests/osautoinst/test_running.pm
+++ b/tests/osautoinst/test_running.pm
@@ -4,7 +4,7 @@ use testapi;
 
 sub run {
     assert_script_run 'command -v ack >/dev/null || zypper --no-refresh -n in ack';
-    assert_script_run 'ret=false; for i in {1..5} ; do openqa-client jobs state=running | ack --passthru --color running && ret=true && break ; sleep 30 ; done ; [ "$ret" = "true" ]', 300;
+    assert_script_run 'ret=false; for i in {1..5} ; do openqa-cli api jobs state=running state=done | ack --passthru --color 'running|done' && ret=true && break ; sleep 30 ; done ; [ "$ret" = "true" ]', 300;
     save_screenshot;
     type_string "clear\n";
 }


### PR DESCRIPTION
This has been failing a lot recently (returning an empty list), and it seems
the jobs are getting done too fast to check for a running state.

https://openqa.opensuse.org/group_overview/24?limit_builds=20&limit_builds=50