### PR TITLE
Revert "Add assert_screen to shutdown to ensure console is prepared for input"

### DIFF
--- a/tests/install/openqa_webui.pm
+++ b/tests/install/openqa_webui.pm
@@ -16,6 +16,12 @@ sub install_from_repos {
         my $repo = 'openSUSE_' . $repo_suffix{get_required_var('ARCH')};
         $add_repo = "zypper --non-interactive ar -f obs://devel:openQA/$repo openQA";
     }
+    elsif (check_var('VERSION', '42.3')) {
+        $add_repo = <<'EOF';
+zypper ar -f obs://devel:openQA/openSUSE_Leap_42.3 openQA
+zypper ar -f obs://devel:openQA:Leap:42.3/openSUSE_Leap_42.3 openQA-perl-modules
+EOF
+    }
     elsif (check_var('VERSION', 'SLES-12SP5')) {
         $add_repo = <<'EOF';
 zypper ar -f http://download.opensuse.org/repositories/devel:/openQA/SLE_12_SP5/devel:openQA.repo

--- a/tests/shutdown/shutdown.pm
+++ b/tests/shutdown/shutdown.pm
@@ -3,9 +3,8 @@ use base "openQAcoretest";
 use testapi;
 
 sub run {
-    send_key('ctrl-alt-f3', wait_scren_change => 1) ;
-    assert_screen("root-console");
-    enter_cmd "poweroff";
+    wait_screen_change { send_key 'ctrl-alt-f3' };
+    type_string "poweroff\n";
     assert_shutdown(300);
 }
 


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-openQA#77

Tests are now always failing:
https://openqa.opensuse.org/group_overview/24
https://openqa.opensuse.org/tests/2180406#step/shutdown/2
https://openqa.opensuse.org/tests/2180389#step/shutdown/2