### PR TITLE
Shutdown stability

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -6,7 +6,12 @@ use strict;
 use testapi;
 use File::Basename qw(basename);
 
-our @EXPORT = qw(switch_to_x11 wait_for_desktop ensure_unlocked_desktop wait_for_container_log);
+our @EXPORT = qw(clear_root_console switch_to_x11 wait_for_desktop ensure_unlocked_desktop wait_for_container_log);
+
+sub clear_root_console {
+    enter_cmd('clear');
+    assert_screen 'root-console';
+}
 
 sub switch_to_x11 {
     my @hdd = split(/-/, basename get_required_var('HDD_1'));

--- a/tests/containers/worker.pm
+++ b/tests/containers/worker.pm
@@ -8,6 +8,7 @@ sub run {
 
   assert_script_run("docker run -d --network testing $volumes --name openqa_worker openqa_worker");
   wait_for_container_log("openqa_worker", "API key and secret are needed", "docker");
+  clear_root_console;
 }
 
 1;

--- a/tests/install/openqa_webui.pm
+++ b/tests/install/openqa_webui.pm
@@ -16,12 +16,6 @@ sub install_from_repos {
         my $repo = 'openSUSE_' . $repo_suffix{get_required_var('ARCH')};
         $add_repo = "zypper --non-interactive ar -f obs://devel:openQA/$repo openQA";
     }
-    elsif (check_var('VERSION', '42.3')) {
-        $add_repo = <<'EOF';
-zypper ar -f obs://devel:openQA/openSUSE_Leap_42.3 openQA
-zypper ar -f obs://devel:openQA:Leap:42.3/openSUSE_Leap_42.3 openQA-perl-modules
-EOF
-    }
     elsif (check_var('VERSION', 'SLES-12SP5')) {
         $add_repo = <<'EOF';
 zypper ar -f http://download.opensuse.org/repositories/devel:/openQA/SLE_12_SP5/devel:openQA.repo

--- a/tests/install/openqa_webui.pm
+++ b/tests/install/openqa_webui.pm
@@ -88,7 +88,7 @@ sub run {
         install_from_repos;
     }
     save_screenshot;
-    type_string "clear\n";
+    clear_root_console;
 }
 
 1;

--- a/tests/install/openqa_worker.pm
+++ b/tests/install/openqa_worker.pm
@@ -25,7 +25,7 @@ systemctl enable openqa-worker@1
 EOF
     assert_script_run($_) foreach (split /\n/, $worker_setup);
     save_screenshot;
-    type_string "clear\n";
+    clear_root_console;
 }
 
 1;

--- a/tests/install/test_distribution.pm
+++ b/tests/install/test_distribution.pm
@@ -11,9 +11,9 @@ sub run {
     save_screenshot;
     assert_script_run('zypper -n ref -f',                              60);
     assert_script_run('zypper -n in os-autoinst-distri-opensuse-deps', 600);
-    type_string "clear\n";
+    clear_root_console;
     # prepare for next test
-    type_string "logout\n";
+    enter_cmd "logout";
     switch_to_x11;
 }
 

--- a/tests/osautoinst/start_test.pm
+++ b/tests/osautoinst/start_test.pm
@@ -1,6 +1,7 @@
 use strict;
 use base "openQAcoretest";
 use testapi;
+use utils;
 
 sub run {
     # please forgive the hackiness: using the openQA API but parsing the
@@ -21,7 +22,7 @@ openqa-clone-job --from $openqa_url \$job_id
 EOF
     assert_script_run($_) foreach (split /\n/, $cmd);
     save_screenshot;
-    type_string "clear\n";
+    clear_root_console;
 }
 
 1;

--- a/tests/osautoinst/test_running.pm
+++ b/tests/osautoinst/test_running.pm
@@ -1,12 +1,13 @@
 use strict;
 use base "openQAcoretest";
 use testapi;
+use utils;
 
 sub run {
     assert_script_run 'command -v ack >/dev/null || zypper --no-refresh -n in ack';
     assert_script_run 'ret=false; for i in {1..5} ; do openqa-cli api jobs state=running state=done | ack --passthru --color "running|done" && ret=true && break ; sleep 30 ; done ; [ "$ret" = "true" ]', 300;
     save_screenshot;
-    type_string "clear\n";
+    clear_root_console;
 }
 
 sub post_fail_hook {

--- a/tests/osautoinst/worker.pm
+++ b/tests/osautoinst/worker.pm
@@ -13,7 +13,7 @@ sub run {
     wait_still_screen(2);
     assert_script_run 'systemctl status --no-pager openqa-worker@1 | grep --color -z "active (running)"';
     save_screenshot;
-    type_string "clear\n";
+    clear_root_console;
 }
 
 1;

--- a/tests/shutdown/shutdown.pm
+++ b/tests/shutdown/shutdown.pm
@@ -3,8 +3,9 @@ use base "openQAcoretest";
 use testapi;
 
 sub run {
-    wait_screen_change { send_key 'ctrl-alt-f3' };
-    type_string "poweroff\n";
+    send_key('ctrl-alt-f3');
+    assert_screen("root-console");
+    enter_cmd "poweroff";
     assert_shutdown(300);
 }
 

--- a/tests/update/zypper_up.pm
+++ b/tests/update/zypper_up.pm
@@ -13,7 +13,7 @@ sub run {
     wait_still_screen(2);
     script_run 'systemctl mask --now packagekit';
     save_screenshot;
-    type_string "clear\n";
+    clear_root_console;
     assert_script_run('zypper -n up --auto-agree-with-licenses', timeout => 700, fail_message => 'zypper failed to update packages');
     save_screenshot;
 }


### PR DESCRIPTION
https://progress.opensuse.org/issues/105506

Added clear command to tests using same console as shutdown to make needle match more stable

https://openqa.opensuse.org/tests/2181124#step/shutdown/1