### PR TITLE
Extend timeout for ISO download and show progress

### DIFF
--- a/tests/osautoinst/start_test.pm
+++ b/tests/osautoinst/start_test.pm
@@ -18,9 +18,9 @@ job_id=\$(openqa-client --host $openqa_url --json-output jobs get version=Tumble
 echo "Job Id: \$job_id"
 [ ! -z \$job_id  ]
 echo "Scenario: $arch-$ttest-NET: \$job_id"
-openqa-clone-job --from $openqa_url \$job_id
 EOF
     assert_script_run($_) foreach (split /\n/, $cmd);
+    assert_script_run("openqa-clone-job --show-progress --from $openqa_url \$job_id", timeout => 120);
     save_screenshot;
     clear_root_console;
 }


### PR DESCRIPTION
The test recently ran into a timeout here:
```
Test died: command 'openqa-clone-job --from http://openqa.opensuse.org $job_id' timed out at openqa//tests/osautoinst/start_test.pm line 23.
```

Likely it just too longer than 90 seconds to download the ISO file.

See https://progress.opensuse.org/issues/106919