### PR TITLE
Allow more time for sporadic zypper and download slowdown

### DIFF
--- a/tests/containers/build.pm
+++ b/tests/containers/build.pm
@@ -5,9 +5,9 @@ use testapi;
 sub run {
     my ($self) = @_;
     assert_script_run("git clone https://github.com/os-autoinst/openQA.git", timeout => 300);
-    assert_script_run('for i in {1..3}; do docker build openQA/container/webui -t openqa_webui && break; done', timeout => 1000);
-    assert_script_run('for i in {1..3}; do docker build openQA/container/worker -t openqa_worker && break; done', timeout => 1000);
-    assert_script_run('for i in {1..3}; do docker build openQA/container/openqa_data -t openqa_data && break; done', timeout => 1000);
+    assert_script_run('for i in {1..3}; do docker build openQA/container/webui -t openqa_webui && break; done', timeout => 3600);
+    assert_script_run('for i in {1..3}; do docker build openQA/container/worker -t openqa_worker && break; done', timeout => 3600);
+    assert_script_run('for i in {1..3}; do docker build openQA/container/openqa_data -t openqa_data && break; done', timeout => 3600);
 }
 
 1;


### PR DESCRIPTION
In multiple occassions we found zypper calls to take a very long time in
both the webui as well as worker preparation steps which involve
downloading multiple packages. This commit bumps the timeout from 1000s
to a full hour to account for random slowness.

Related progress issue: https://progress.opensuse.org/issues/108665