### PR TITLE
Fix missing postgres server dependency

### DIFF
--- a/tests/install/openqa_webui.pm
+++ b/tests/install/openqa_webui.pm
@@ -16,7 +16,7 @@ sub install_from_repos {
     my $repo = 'openSUSE_' . $repo_suffix{get_required_var('ARCH')};
     $add_repo = "zypper --non-interactive ar -f obs://devel:openQA/$repo openQA";
     assert_script_run($_) foreach (split /\n/, $add_repo);
-    assert_script_run('zypper --no-cd --non-interactive --gpg-auto-import-keys in openQA', 600);
+    assert_script_run('zypper --no-cd --non-interactive --gpg-auto-import-keys in openQA-local-db', 600);
     my $configure = <<'EOF';
 /usr/share/openqa/script/configure-web-proxy
 sed -i -e 's/#.*method.*OpenID.*$/&\nmethod = Fake/' /etc/openqa/openqa.ini

--- a/tests/install/openqa_webui.pm
+++ b/tests/install/openqa_webui.pm
@@ -7,24 +7,14 @@ use utils;
 sub install_from_repos {
     diag('following https://github.com/os-autoinst/openQA/blob/master/docs/Installing.asciidoc');
     my $add_repo;
-    if (get_required_var('VERSION') =~ /(tw|Tumbleweed)/) {
-        my %repo_suffix = (
-            x86_64  => 'Tumbleweed',
-            aarch64 => 'Factory_ARM',
-            ppc64le => 'Factory_PowerPC'
-        );
-        my $repo = 'openSUSE_' . $repo_suffix{get_required_var('ARCH')};
-        $add_repo = "zypper --non-interactive ar -f obs://devel:openQA/$repo openQA";
-    }
-    elsif (check_var('VERSION', 'SLES-12SP5')) {
-        $add_repo = <<'EOF';
-zypper ar -f http://download.opensuse.org/repositories/devel:/openQA/SLE_12_SP5/devel:openQA.repo
-zypper ar -f http://download.opensuse.org/repositories/devel:/openQA:/SLE-12/SLE_12_SP5/devel:openQA:SLE-12.repo
-EOF
-    }
-    else {
-        die "Needs implementation for other versions";
-    }
+    die 'Needs implementation for other versions' unless get_required_var('VERSION') =~ /(tw|Tumbleweed)/;
+    my %repo_suffix = (
+        x86_64  => 'Tumbleweed',
+        aarch64 => 'Factory_ARM',
+        ppc64le => 'Factory_PowerPC'
+    );
+    my $repo = 'openSUSE_' . $repo_suffix{get_required_var('ARCH')};
+    $add_repo = "zypper --non-interactive ar -f obs://devel:openQA/$repo openQA";
     assert_script_run($_) foreach (split /\n/, $add_repo);
     assert_script_run('zypper --no-cd --non-interactive --gpg-auto-import-keys in openQA', 600);
     my $configure = <<'EOF';


### PR DESCRIPTION
As we depend on the postgreSQL server we either need to explicitly
install those packages are select openQA-local-db directly which was not
pulled in anymore.

```
openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-openQA/pull/83 https://openqa.opensuse.org/tests/2305021
```

Created job #2306269: openqa-Tumbleweed-dev-x86_64-Build:TW.11108-openqa_install+publish@64bit-2G -> https://openqa.opensuse.org/t2306269 (passed)

Related progress issue: https://progress.opensuse.org/issues/110089