### PR TITLE
Accept random slow 'zypper ref' calls

### DIFF
--- a/tests/install/test_distribution.pm
+++ b/tests/install/test_distribution.pm
@@ -9,7 +9,7 @@ sub run {
     diag('initialize working copy of openSUSE tests distribution with correct user');
     assert_script_run('username=bernhard email=bernhard@susetest /usr/share/openqa/script/fetchneedles', 3600);
     save_screenshot;
-    assert_script_run('zypper -n ref -f',                              60);
+    assert_script_run('zypper -n ref -f',                              300);
     assert_script_run('zypper -n in os-autoinst-distri-opensuse-deps', 600);
     clear_root_console;
     # prepare for next test


### PR DESCRIPTION
https://openqa.opensuse.org/tests/2383839#step/test_distribution/4 hit
the timeout due to extra-slow execution of zypper ref. I have also seen
slow zypper ref executions in many other occassions so I guess we should
just live with that.