### PR TITLE
Retry on most zypper calls to workaround broken repositories

### DIFF
--- a/tests/install/openqa_webui.pm
+++ b/tests/install/openqa_webui.pm
@@ -16,7 +16,7 @@ sub install_from_repos {
     my $repo = 'openSUSE_' . $repo_suffix{get_required_var('ARCH')};
     $add_repo = "zypper --non-interactive ar -f obs://devel:openQA/$repo openQA";
     assert_script_run($_) foreach (split /\n/, $add_repo);
-    assert_script_run('zypper --no-cd --non-interactive --gpg-auto-import-keys in openQA-local-db', 600);
+    assert_script_run('for i in {1..3}; do zypper --no-cd --non-interactive --gpg-auto-import-keys in openQA-local-db && break; done', 600);
     my $configure = <<'EOF';
 /usr/share/openqa/script/configure-web-proxy
 sed -i -e 's/#.*method.*OpenID.*$/&\nmethod = Fake/' /etc/openqa/openqa.ini
@@ -32,13 +32,13 @@ EOF
 
 sub install_from_git {
     my $configure = <<'EOF';
-zypper --non-interactive in -C 'rubygem(sass)' git-core perl-App-cpanminus perl-Module-CPANfile perl-YAML-LibYAML postgresql-server apache2
+for i in {1..3; do zypper --non-interactive in -C 'rubygem(sass)' git-core perl-App-cpanminus perl-Module-CPANfile perl-YAML-LibYAML postgresql-server apache2 && break; done
 systemctl start postgresql || systemctl status --no-pager postgresql
 su - postgres -c 'createuser root'
 su - postgres -c 'createdb -O root openqa'
 git clone https://github.com/os-autoinst/openQA.git
 cd openQA
-for p in $(cpanfile-dump); do echo -n "perl($p) "; done | xargs zypper --non-interactive in -C
+pkgs=$(for p in $(cpanfile-dump); do echo -n "perl($p) "; done); for i in {1..3}; do echo zypper --non-interactive in -C $pkgs && break; done
 cpanm -nq --installdeps .
 for i in headers proxy proxy_http proxy_wstunnel rewrite ; do a2enmod $i ; done
 cp etc/apache2/vhosts.d/openqa-common.inc /etc/apache2/vhosts.d/
@@ -53,7 +53,7 @@ EOF
 }
 
 sub install_containers {
-    assert_script_run("zypper --non-interactive install docker git", timeout => 600);
+    assert_script_run('for i in {1.. 3}; do zypper --non-interactive install docker git && break; done', timeout => 600);
     assert_script_run("systemctl start docker");
 }
 

--- a/tests/install/openqa_worker.pm
+++ b/tests/install/openqa_worker.pm
@@ -5,9 +5,9 @@ use utils;
 
 sub run {
     diag('worker setup');
-    assert_script_run('zypper -n --gpg-auto-import-keys ref -f',           60);
-    assert_script_run('zypper --no-cd --non-interactive in os-autoinst',   600);
-    assert_script_run('zypper --no-cd --non-interactive in openQA-worker', 600);
+    assert_script_run('for i in {1..3}; do zypper -n --gpg-auto-import-keys ref -f && break; done', 300);
+    assert_script_run('for i in {1..3}; do zypper --no-cd --non-interactive in os-autoinst && break; done', 600);
+    assert_script_run('for i in {1..3}; do zypper --no-cd --non-interactive in openQA-worker && break; done', 600);
     diag('Login once with fake authentication on openqa webUI to actually create preconfigured API keys for worker authentication');
     assert_script_run('curl http://localhost/login');
     diag('adding temporary, preconfigured API keys to worker config');

--- a/tests/install/test_distribution.pm
+++ b/tests/install/test_distribution.pm
@@ -9,8 +9,8 @@ sub run {
     diag('initialize working copy of openSUSE tests distribution with correct user');
     assert_script_run('username=bernhard email=bernhard@susetest /usr/share/openqa/script/fetchneedles', 3600);
     save_screenshot;
-    assert_script_run('zypper -n ref -f',                              300);
-    assert_script_run('zypper -n in os-autoinst-distri-opensuse-deps', 600);
+    assert_script_run('for i in {1..3}; do zypper -n ref -f && break; done', 300);
+    assert_script_run('for i in {1..3}; do zypper -n in os-autoinst-distri-opensuse-deps && break; done ', 600);
     clear_root_console;
     # prepare for next test
     enter_cmd "logout";

--- a/tests/update/zypper_up.pm
+++ b/tests/update/zypper_up.pm
@@ -14,7 +14,7 @@ sub run {
     script_run 'systemctl mask --now packagekit';
     save_screenshot;
     clear_root_console;
-    assert_script_run('zypper -n up --auto-agree-with-licenses', timeout => 700, fail_message => 'zypper failed to update packages');
+    assert_script_run('for i in {1..3}; do zypper -n up --auto-agree-with-licenses && break; done', timeout => 700, fail_message => 'zypper failed to update packages');
     save_screenshot;
 }
 


### PR DESCRIPTION
The overall problem is also reported in
https://github.com/openSUSE/zypper/issues/420#issuecomment-1150843963 on
the report https://github.com/openSUSE/zypper/issues/420 which I had
opened months ago.

This problem hits us multiple times a week and we already try to handle
it with downstream retrying on multiple levels.
os-autoinst-distri-opensuse tests are hit by the same problem
recurringly and also seemingly much more than months or years ago. There
are also reports by other users.

This commit changes most zypper calls to use a retry loop same as we
recently already added in the container setup test module. I only kept
the single zypper call for small packages which are likely coming from
main repositories, e.g. "jq".

Related progress issue: https://progress.opensuse.org/issues/112232