### PR TITLE
Try to fix conflicting zypper repo status with wait+refresh

### DIFF
--- a/tests/install/openqa_webui.pm
+++ b/tests/install/openqa_webui.pm
@@ -27,7 +27,6 @@ systemctl enable --now openqa-scheduler
 systemctl status --no-pager openqa-scheduler
 EOF
     assert_script_run($_) foreach (split /\n/, $configure);
-    script_run('systemctl unmask packagekit; systemctl start packagekit');
 }
 
 sub install_from_git {
@@ -65,7 +64,7 @@ sub run {
     type_string $testapi::password . "\n";
     wait_still_screen(2);
     diag('Ensure packagekit is not interfering with zypper calls');
-    script_run('systemctl stop packagekit.service; systemctl mask packagekit.service');
+    assert_script_run('systemctl mask --now packagekit');
     if (check_var('OPENQA_FROM_GIT', 1)) {
         if (get_var('OPENQA_CONTAINERS')) {
             install_containers;

--- a/tests/install/openqa_webui.pm
+++ b/tests/install/openqa_webui.pm
@@ -14,9 +14,9 @@ sub install_from_repos {
         ppc64le => 'Factory_PowerPC'
     );
     my $repo = 'openSUSE_' . $repo_suffix{get_required_var('ARCH')};
-    $add_repo = "zypper -n ar -f obs://devel:openQA/$repo openQA";
+    $add_repo = "zypper -n ar -p 95 -f obs://devel:openQA/$repo openQA";
     assert_script_run($_) foreach (split /\n/, $add_repo);
-    assert_script_run('for i in {1..3}; do zypper --no-cd -n --gpg-auto-import-keys in openQA-local-db && break || sleep 30 && zypper -n ref; done', 600);
+    assert_script_run('for i in {1..3}; do zypper --no-cd -n --gpg-auto-import-keys in openQA-local-db && break || sleep 30; false; done', 600);
     my $configure = <<'EOF';
 /usr/share/openqa/script/configure-web-proxy
 sed -i -e 's/#.*method.*OpenID.*$/&\nmethod = Fake/' /etc/openqa/openqa.ini
@@ -32,13 +32,13 @@ EOF
 
 sub install_from_git {
     my $configure = <<'EOF';
-for i in {1..3}; do zypper -n in -C 'rubygem(sass)' git-core perl-App-cpanminus perl-Module-CPANfile perl-YAML-LibYAML postgresql-server apache2 && break || sleep 30 && zypper -n ref; done
+for i in {1..3}; do zypper -n in -C 'rubygem(sass)' git-core perl-App-cpanminus perl-Module-CPANfile perl-YAML-LibYAML postgresql-server apache2 && break || sleep 30; false; done
 systemctl start postgresql || systemctl status --no-pager postgresql
 su - postgres -c 'createuser root'
 su - postgres -c 'createdb -O root openqa'
 git clone https://github.com/os-autoinst/openQA.git
 cd openQA
-pkgs=$(for p in $(cpanfile-dump); do echo -n "perl($p) "; done); for i in {1..3}; do echo zypper -n in -C $pkgs && break || sleep 30 && zypper -n ref; done
+pkgs=$(for p in $(cpanfile-dump); do echo -n "perl($p) "; done); for i in {1..3}; do echo zypper -n in -C $pkgs && break || sleep 30; false; done
 cpanm -nq --installdeps .
 for i in headers proxy proxy_http proxy_wstunnel rewrite ; do a2enmod $i ; done
 cp etc/apache2/vhosts.d/openqa-common.inc /etc/apache2/vhosts.d/
@@ -53,7 +53,7 @@ EOF
 }
 
 sub install_containers {
-    assert_script_run('for i in {1.. 3}; do zypper -n in docker git && break || sleep 30 && zypper -n ref; done', timeout => 600);
+    assert_script_run('for i in {1.. 3}; do zypper -n in docker git && break || sleep 30; false; done', timeout => 600);
     assert_script_run("systemctl start docker");
 }
 

--- a/tests/install/openqa_worker.pm
+++ b/tests/install/openqa_worker.pm
@@ -5,9 +5,7 @@ use utils;
 
 sub run {
     diag('worker setup');
-    assert_script_run('for i in {1..3}; do zypper -n --gpg-auto-import-keys ref -f && break; done', 300);
-    assert_script_run('for i in {1..3}; do zypper --no-cd --non-interactive in os-autoinst && break; done', 600);
-    assert_script_run('for i in {1..3}; do zypper --no-cd --non-interactive in openQA-worker && break; done', 600);
+    assert_script_run('for i in {1..3}; do zypper --no-cd -n --gpg-auto-import-keys in openQA-worker && break || sleep 30 && zypper -n ref; done', 600);
     diag('Login once with fake authentication on openqa webUI to actually create preconfigured API keys for worker authentication');
     assert_script_run('curl http://localhost/login');
     diag('adding temporary, preconfigured API keys to worker config');

--- a/tests/install/openqa_worker.pm
+++ b/tests/install/openqa_worker.pm
@@ -5,7 +5,7 @@ use utils;
 
 sub run {
     diag('worker setup');
-    assert_script_run('for i in {1..3}; do zypper --no-cd -n --gpg-auto-import-keys in openQA-worker && break || sleep 30 && zypper -n ref; done', 600);
+    assert_script_run('for i in {1..3}; do zypper --no-cd -n --gpg-auto-import-keys in openQA-worker && break || sleep 30; false; done', 600);
     diag('Login once with fake authentication on openqa webUI to actually create preconfigured API keys for worker authentication');
     assert_script_run('curl http://localhost/login');
     diag('adding temporary, preconfigured API keys to worker config');

--- a/tests/install/test_distribution.pm
+++ b/tests/install/test_distribution.pm
@@ -9,8 +9,7 @@ sub run {
     diag('initialize working copy of openSUSE tests distribution with correct user');
     assert_script_run('username=bernhard email=bernhard@susetest /usr/share/openqa/script/fetchneedles', 3600);
     save_screenshot;
-    assert_script_run('for i in {1..3}; do zypper -n ref -f && break; done', 300);
-    assert_script_run('for i in {1..3}; do zypper -n in os-autoinst-distri-opensuse-deps && break; done ', 600);
+    assert_script_run('for i in {1..3}; do zypper -n in os-autoinst-distri-opensuse-deps && break || sleep 30 && zypper -n ref; done', 600);
     clear_root_console;
     # prepare for next test
     enter_cmd "logout";

--- a/tests/install/test_distribution.pm
+++ b/tests/install/test_distribution.pm
@@ -9,7 +9,7 @@ sub run {
     diag('initialize working copy of openSUSE tests distribution with correct user');
     assert_script_run('username=bernhard email=bernhard@susetest /usr/share/openqa/script/fetchneedles', 3600);
     save_screenshot;
-    assert_script_run('for i in {1..3}; do zypper -n in os-autoinst-distri-opensuse-deps && break || sleep 30 && zypper -n ref; done', 600);
+    assert_script_run('for i in {1..3}; do zypper -n in os-autoinst-distri-opensuse-deps && break || sleep 30; false; done', 600);
     clear_root_console;
     # prepare for next test
     enter_cmd "logout";

--- a/tests/update/zypper_up.pm
+++ b/tests/update/zypper_up.pm
@@ -14,7 +14,7 @@ sub run {
     script_run 'systemctl mask --now packagekit';
     save_screenshot;
     clear_root_console;
-    assert_script_run('for i in {1..3}; do zypper -n up --auto-agree-with-licenses && break || sleep 30 && zypper -n ref; done', timeout => 700, fail_message => 'zypper failed to update packages');
+    assert_script_run('for i in {1..3}; do zypper -n up --auto-agree-with-licenses && break || sleep 30; false; done', timeout => 700, fail_message => 'zypper failed to update packages');
     save_screenshot;
 }
 

--- a/tests/update/zypper_up.pm
+++ b/tests/update/zypper_up.pm
@@ -11,7 +11,7 @@ sub run {
     assert_screen "password-prompt";
     type_string "1\n";
     wait_still_screen(2);
-    script_run 'systemctl mask --now packagekit';
+    assert_script_run 'systemctl mask --now packagekit';
     save_screenshot;
     clear_root_console;
     assert_script_run('for i in {1..3}; do zypper -n up --auto-agree-with-licenses && break || sleep 30; false; done', timeout => 700, fail_message => 'zypper failed to update packages');

--- a/tests/update/zypper_up.pm
+++ b/tests/update/zypper_up.pm
@@ -14,7 +14,7 @@ sub run {
     script_run 'systemctl mask --now packagekit';
     save_screenshot;
     clear_root_console;
-    assert_script_run('for i in {1..3}; do zypper -n up --auto-agree-with-licenses && break; done', timeout => 700, fail_message => 'zypper failed to update packages');
+    assert_script_run('for i in {1..3}; do zypper -n up --auto-agree-with-licenses && break || sleep 30 && zypper -n ref; done', timeout => 700, fail_message => 'zypper failed to update packages');
     save_screenshot;
 }
 


### PR DESCRIPTION
zypper should automatically refresh whenever metadata appears as out of
date. However even with multiple retries we still encounter cases when
repository content appears to be inconsistent. At latest encountered in
https://openqa.opensuse.org/t2410284#step/openqa_worker/5

This PR changes the loops already in place around zypper in calls to
conduct a delayed retry as well as use repo priorities, same as we
suggest in openQA documentation

https://openqa.opensuse.org/tests/2410586/video?filename=video.ogv&t=10
shows how on an initial try package installation fails because the
repository is in an inconsistent state. On retry the installation
works fine as in the meantime a new package for os-autoinst
is fully published.

```
MARKDOWN=1 openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-openQA/pull/90 https://openqa.opensuse.org/tests/2410284
```

<!-- previous verification run, failed due to missing repository priorities
* [openqa-Tumbleweed-dev-x86_64-Build:TW.11602-openqa_install+publish@64bit-2G](https://openqa.opensuse.org/t2410585)
-->

https://openqa.opensuse.org/2410633

Related progress issue: https://progress.opensuse.org/issues/112232