### PR TITLE
Simplify "retry" operations with openSUSE Tumbleweed's new retry command

### DIFF
--- a/tests/containers/build.pm
+++ b/tests/containers/build.pm
@@ -5,9 +5,8 @@ use testapi;
 sub run {
     my ($self) = @_;
     assert_script_run("git clone https://github.com/os-autoinst/openQA.git", timeout => 300);
-    assert_script_run('for i in {1..3}; do docker build openQA/container/webui -t openqa_webui && break; done', timeout => 3600);
-    assert_script_run('for i in {1..3}; do docker build openQA/container/worker -t openqa_worker && break; done', timeout => 3600);
-    assert_script_run('for i in {1..3}; do docker build openQA/container/openqa_data -t openqa_data && break; done', timeout => 3600);
+    assert_script_run('for i in webui worker; do retry -s 30 -- docker build openQA/container/$i -t openqa_$i; done', timeout => 4800);
+    assert_script_run('retry -s 30 -- docker build openQA/container/openqa_data -t openqa_datai', timeout => 3600);
 }
 
 1;

--- a/tests/containers/setup_env.pm
+++ b/tests/containers/setup_env.pm
@@ -7,7 +7,7 @@ sub run {
 
    assert_script_run("mkdir -p /root/data/factory/{iso,hdd,other} /root/data/tests");
    assert_script_run("docker network create testing");
-   assert_script_run("for i in {1..3}; do docker run --rm -d --network testing -e POSTGRES_PASSWORD=openqa -e POSTGRES_USER=openqa -e POSTGRES_DB=openqa --net-alias=db --name db postgres && break; done", timeout => 600);
+   assert_script_run("retry -s 30 -- docker run --rm -d --network testing -e POSTGRES_PASSWORD=openqa -e POSTGRES_USER=openqa -e POSTGRES_DB=openqa --net-alias=db --name db postgres", timeout => 600);
    wait_for_container_log("db", "database system is ready to accept connections", "docker");
 }
 

--- a/tests/install/openqa_webui.pm
+++ b/tests/install/openqa_webui.pm
@@ -5,6 +5,7 @@ use utils;
 
 
 sub install_from_repos {
+    assert_script_run('retry -s 30 -- zypper --no-cd -n --gpg-auto-import-keys in openQA-local-db', 600);
     diag('following https://github.com/os-autoinst/openQA/blob/master/docs/Installing.asciidoc');
     my $add_repo;
     die 'Needs implementation for other versions' unless get_required_var('VERSION') =~ /(tw|Tumbleweed)/;
@@ -16,7 +17,7 @@ sub install_from_repos {
     my $repo = 'openSUSE_' . $repo_suffix{get_required_var('ARCH')};
     $add_repo = "zypper -n ar -p 95 -f obs://devel:openQA/$repo openQA";
     assert_script_run($_) foreach (split /\n/, $add_repo);
-    assert_script_run('for i in {1..3}; do zypper --no-cd -n --gpg-auto-import-keys in openQA-local-db && break || sleep 30; false; done', 600);
+    assert_script_run('retry -s 30 -- zypper --no-cd -n --gpg-auto-import-keys in openQA-local-db', 600);
     my $configure = <<'EOF';
 /usr/share/openqa/script/configure-web-proxy
 sed -i -e 's/#.*method.*OpenID.*$/&\nmethod = Fake/' /etc/openqa/openqa.ini
@@ -31,13 +32,13 @@ EOF
 
 sub install_from_git {
     my $configure = <<'EOF';
-for i in {1..3}; do zypper -n in -C 'rubygem(sass)' git-core perl-App-cpanminus perl-Module-CPANfile perl-YAML-LibYAML postgresql-server apache2 && break || sleep 30; false; done
+retry -s 30 -- zypper -n in -C 'rubygem(sass)' git-core perl-App-cpanminus perl-Module-CPANfile perl-YAML-LibYAML postgresql-server apache2
 systemctl start postgresql || systemctl status --no-pager postgresql
 su - postgres -c 'createuser root'
 su - postgres -c 'createdb -O root openqa'
 git clone https://github.com/os-autoinst/openQA.git
 cd openQA
-pkgs=$(for p in $(cpanfile-dump); do echo -n "perl($p) "; done); for i in {1..3}; do zypper -n in -C $pkgs && break || sleep 30; false; done
+pkgs=$(for p in $(cpanfile-dump); do echo -n "perl($p) "; done); retry -s 30 -- zypper -n in -C $pkgs
 cpanm -nq --installdeps .
 for i in headers proxy proxy_http proxy_wstunnel rewrite ; do a2enmod $i ; done
 cp etc/apache2/vhosts.d/openqa-common.inc /etc/apache2/vhosts.d/
@@ -52,7 +53,7 @@ EOF
 }
 
 sub install_containers {
-    assert_script_run('for i in {1.. 3}; do zypper -n in docker git && break || sleep 30; false; done', timeout => 600);
+    assert_script_run('retry -s 30 -- zypper -n in docker git', timeout => 600);
     assert_script_run("systemctl start docker");
 }
 
@@ -65,6 +66,7 @@ sub run {
     wait_still_screen(2);
     diag('Ensure packagekit is not interfering with zypper calls');
     assert_script_run('systemctl mask --now packagekit');
+    assert_script_run('zypper --no-cd -n in retry');
     if (check_var('OPENQA_FROM_GIT', 1)) {
         if (get_var('OPENQA_CONTAINERS')) {
             install_containers;

--- a/tests/install/openqa_worker.pm
+++ b/tests/install/openqa_worker.pm
@@ -5,7 +5,7 @@ use utils;
 
 sub run {
     diag('worker setup');
-    assert_script_run('for i in {1..3}; do zypper --no-cd -n --gpg-auto-import-keys in openQA-worker && break || sleep 30; false; done', 600);
+    assert_script_run('retry -s 30 -- zypper --no-cd -n --gpg-auto-import-keys in openQA-worker', 600);
     diag('Login once with fake authentication on openqa webUI to actually create preconfigured API keys for worker authentication');
     assert_script_run('curl http://localhost/login');
     diag('adding temporary, preconfigured API keys to worker config');

--- a/tests/install/test_distribution.pm
+++ b/tests/install/test_distribution.pm
@@ -9,7 +9,7 @@ sub run {
     diag('initialize working copy of openSUSE tests distribution with correct user');
     assert_script_run('username=bernhard email=bernhard@susetest /usr/share/openqa/script/fetchneedles', 3600);
     save_screenshot;
-    assert_script_run('for i in {1..3}; do zypper -n in os-autoinst-distri-opensuse-deps && break || sleep 30; false; done', 600);
+    assert_script_run('retry -s 30 -- zypper -n in os-autoinst-distri-opensuse-deps', 600);
     clear_root_console;
     # prepare for next test
     enter_cmd "logout";

--- a/tests/osautoinst/test_running.pm
+++ b/tests/osautoinst/test_running.pm
@@ -5,7 +5,7 @@ use utils;
 
 sub run {
     assert_script_run 'command -v ack >/dev/null || zypper --no-refresh -n in ack';
-    assert_script_run 'ret=false; for i in {1..5} ; do openqa-cli api jobs state=running state=done | ack --passthru --color "running|done" && ret=true && break ; sleep 30 ; done ; [ "$ret" = "true" ]', 300;
+    assert_script_run 'retry -s 30 -r 5 -- openqa-cli api jobs state=running state=done | ack --passthru --color "running|done"', 300;
     save_screenshot;
     clear_root_console;
 }

--- a/tests/update/zypper_up.pm
+++ b/tests/update/zypper_up.pm
@@ -14,7 +14,7 @@ sub run {
     assert_script_run 'systemctl mask --now packagekit';
     save_screenshot;
     clear_root_console;
-    assert_script_run('for i in {1..3}; do zypper -n up --auto-agree-with-licenses && break || sleep 30; false; done', timeout => 700, fail_message => 'zypper failed to update packages');
+    assert_script_run('retry -s 30 -- zypper -n up --auto-agree-with-licenses', timeout => 700, fail_message => 'zypper failed to update packages');
     save_screenshot;
 }
 


### PR DESCRIPTION
See https://software.opensuse.org/package/retry about the retry package
in openSUSE.

Verification runs:
```
for i in https://openqa.opensuse.org/tests/2438203 https://openqa.opensuse.org/tests/2438204 ; do MARKDOWN=1 openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-openQA/pull/92 $i; done
```

* https://openqa.opensuse.org/tests/2438279
* https://openqa.opensuse.org/tests/2438281