### PR TITLE
Cleanup needles for root-console

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -9,7 +9,8 @@ use File::Basename qw(basename);
 our @EXPORT = qw(clear_root_console switch_to_x11 wait_for_desktop ensure_unlocked_desktop wait_for_container_log prepare_firefox_autoconfig);
 
 sub clear_root_console {
-    enter_cmd('clear');
+    enter_cmd 'clear';
+    enter_cmd 'cd';
     assert_screen 'root-console';
 }
 

--- a/tests/shutdown/shutdown.pm
+++ b/tests/shutdown/shutdown.pm
@@ -3,15 +3,16 @@ use base "openQAcoretest";
 use testapi;
 
 sub run {
-    send_key('ctrl-alt-f3');
-    assert_screen("root-console");
+    send_key 'ctrl-alt-f3';
+    enter_cmd 'cd';
+    assert_screen "root-console";
     enter_cmd "poweroff";
-    assert_shutdown(300);
+    assert_shutdown 300;
 }
 
 sub post_fail_hook {
     # in case plymouth splash screen on shutdown hides some messages
-    send_key 'esc' if check_screen('plymouth');
+    send_key 'esc' if check_screen 'plymouth';
 }
 
 1;


### PR DESCRIPTION
We only need one needle for several test steps. For that
we make sure we go into the root directory first.

Issue: https://progress.opensuse.org/issues/112535