### PR TITLE
Fix failed os-autoinst-distri-opensuse-deps install attempts

### DIFF
--- a/tests/install/test_distribution.pm
+++ b/tests/install/test_distribution.pm
@@ -9,7 +9,11 @@ sub run {
     diag('initialize working copy of openSUSE tests distribution with correct user');
     assert_script_run('username=bernhard email=bernhard@susetest /usr/share/openqa/script/fetchneedles', 3600);
     save_screenshot;
-    assert_script_run('retry -s 30 -- zypper -n in os-autoinst-distri-opensuse-deps', 600);
+    # os-autoinst-distri-opensuse is changing quickly so it is likely to have
+    # changes within the 10 minutes refresh dead-time applied by default in
+    # /etc/zypp/zypp.conf so we need to refresh explicitly with retries in
+    # case of problems.
+    assert_script_run('retry -s 30 -- sh -c "zypper ref && zypper -n in os-autoinst-distri-opensuse-deps"', 600);
     clear_root_console;
     # prepare for next test
     enter_cmd "logout";


### PR DESCRIPTION
Despite retrying the installation of os-autoinst-distri-opensuse-deps
can still fail when the package changes and a new RPM file appears. For
that apparently we can not rely on the implicit repo refresh that should
be spawned by 'zypper in' so we do that explicitly in the retry
attempts.

Should fix https://openqa.opensuse.org/tests/2471623#step/test_distribution/4

Verification run:

```
openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-openQA/pull/95 https://openqa.opensuse.org/tests/2471623
```

* [openqa-Tumbleweed-dev-x86_64-Build:TW.11893-openqa_install+publish@64bit-2G](https://openqa.opensuse.org/t2472686)