### PR TITLE
PART 2: Use retry on openqa-cli calls as well - after #97

### DIFF
--- a/tests/osautoinst/start_test.pm
+++ b/tests/osautoinst/start_test.pm
@@ -10,17 +10,17 @@ sub run {
     my $ttest      = 'minimalx';
     my $openqa_url = get_var('OPENQA_HOST', 'https://openqa.opensuse.org');
     my $cmd        = <<"EOF";
-last_tw_build=\$(openqa-cli api --host $openqa_url assets | jq '.assets | .[] | .name' | sed -n 's/.*Tumbleweed-NET-$arch-Snapshot\\([0-9]\\+\\)-Media.*\$/\\1/p' | sort -n | tail -n 1)
+last_tw_build=\$(OPENQA_CLI_RETRIES=5 openqa-cli api --host $openqa_url assets | jq '.assets | .[] | .name' | sed -n 's/.*Tumbleweed-NET-$arch-Snapshot\\([0-9]\\+\\)-Media.*\$/\\1/p' | sort -n | tail -n 1)
 echo "Last Tumbleweed build on openqa.opensuse.org: \$last_tw_build"
 [ ! -z \$last_tw_build ]
 zypper -n in jq
-job_id=\$(openqa-cli api --host $openqa_url jobs version=Tumbleweed scope=relevant arch=$arch build=\$last_tw_build flavor=NET latest=1 | jq '.jobs | .[] | select(.test == "$ttest") | .id')
+job_id=\$(OPENQA_CLI_RETRIES=5 openqa-cli api --host $openqa_url jobs version=Tumbleweed scope=relevant arch=$arch build=\$last_tw_build flavor=NET latest=1 | jq '.jobs | .[] | select(.test == "$ttest") | .id')
 echo "Job Id: \$job_id"
 [ ! -z \$job_id  ]
 echo "Scenario: $arch-$ttest-NET: \$job_id"
 EOF
     assert_script_run($_) foreach (split /\n/, $cmd);
-    assert_script_run("openqa-clone-job --show-progress --from $openqa_url \$job_id", timeout => 120);
+    assert_script_run("retry -- openqa-clone-job --show-progress --from $openqa_url \$job_id", timeout => 120);
     save_screenshot;
     clear_root_console;
 }


### PR DESCRIPTION
After:
* https://github.com/os-autoinst/os-autoinst-distri-openQA/pull/97

There can be temporary unavailable openQA instances so better use retry
here as well.

Related progress issue: https://progress.opensuse.org/issues/115334