### PR TITLE
Improve error handling in container build tests

### DIFF
--- a/tests/containers/build.pm
+++ b/tests/containers/build.pm
@@ -5,7 +5,7 @@ use testapi;
 sub run {
     my ($self) = @_;
     assert_script_run("git clone https://github.com/os-autoinst/openQA.git", timeout => 300);
-    assert_script_run('for i in webui worker; do retry -s 30 -- docker build openQA/container/$i -t openqa_$i; done', timeout => 4800);
+    assert_script_run("retry -s 30 -- docker build openQA/container/$_ -t openqa_$_", timeout => 2400) for qw(webui worker);
     assert_script_run('retry -s 30 -- docker build openQA/container/openqa_data -t openqa_datai', timeout => 3600);
 }
 

--- a/tests/containers/build.pm
+++ b/tests/containers/build.pm
@@ -6,7 +6,7 @@ sub run {
     my ($self) = @_;
     assert_script_run("git clone https://github.com/os-autoinst/openQA.git", timeout => 300);
     assert_script_run("retry -s 30 -- docker build openQA/container/$_ -t openqa_$_", timeout => 2400) for qw(webui worker);
-    assert_script_run('retry -s 30 -- docker build openQA/container/openqa_data -t openqa_datai', timeout => 3600);
+    assert_script_run('retry -s 30 -- docker build openQA/container/openqa_data -t openqa_data', timeout => 3600);
 }
 
 1;


### PR DESCRIPTION
The for-loop on Bash level would not make the execution stop
when the webui-container build fails. That makes it hard to trace
what the source of the problem was.

This doesn't fix the root cause of
https://progress.opensuse.org/issues/116107 but should make
debugging easier.