### PR TITLE
Enable exponential backoff when retrying container builds

### DIFF
--- a/tests/containers/build.pm
+++ b/tests/containers/build.pm
@@ -5,8 +5,8 @@ use testapi;
 sub run {
     my ($self) = @_;
     assert_script_run("git clone https://github.com/os-autoinst/openQA.git", timeout => 300);
-    assert_script_run("retry -s 30 -- docker build openQA/container/$_ -t openqa_$_", timeout => 2400) for qw(webui worker);
-    assert_script_run('retry -s 30 -- docker build openQA/container/openqa_data -t openqa_data', timeout => 3600);
+    assert_script_run("retry -s 30 -e -- docker build openQA/container/$_ -t openqa_$_", timeout => 2400) for qw(webui worker);
+    assert_script_run('retry -s 30 -e -- docker build openQA/container/openqa_data -t openqa_data', timeout => 3600);
 }
 
 1;


### PR DESCRIPTION
Apparently waiting 30 seconds with just 3 attempts isn't enough, see https://progress.opensuse.org/issues/119245.