### PR TITLE
Avoid openQA worker from appearing broken due to no FQDN

### DIFF
--- a/tests/install/openqa_worker.pm
+++ b/tests/install/openqa_worker.pm
@@ -8,7 +8,7 @@ sub run {
     assert_script_run('retry -s 30 -- sh -c "zypper -n --gpg-auto-import-keys ref && zypper --no-cd -n in openQA-worker"', 600);
     diag('Login once with fake authentication on openqa webUI to actually create preconfigured API keys for worker authentication');
     assert_script_run('curl http://localhost/login');
-    diag('adding temporary, preconfigured API keys to worker config');
+    diag('adding temporary, preconfigured API keys to client config');
     type_string('cat >> /etc/openqa/client.conf <<EOF
 [localhost]
 key = 1234567890ABCDEF
@@ -17,6 +17,7 @@ EOF
 ');
     wait_still_screen(1);
     my $worker_setup = <<'EOF';
+echo "WORKER_HOSTNAME=localhost" >> /etc/openqa/workers.ini
 systemctl start openqa-worker@1
 systemctl status --no-pager openqa-worker@1
 systemctl enable openqa-worker@1


### PR DESCRIPTION
See https://progress.opensuse.org/issues/121567

---

Still a draft because I need to do a verification run (and my local attempts so far were not successful as the test even fails before).