### PR TITLE
Disable packagekit in openqa_worker

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -6,7 +6,7 @@ use strict;
 use testapi;
 use File::Basename qw(basename);
 
-our @EXPORT = qw(clear_root_console switch_to_x11 wait_for_desktop ensure_unlocked_desktop wait_for_container_log prepare_firefox_autoconfig);
+our @EXPORT = qw(clear_root_console switch_to_x11 wait_for_desktop ensure_unlocked_desktop wait_for_container_log prepare_firefox_autoconfig disable_packagekit);
 
 sub clear_root_console {
     enter_cmd 'clear';
@@ -126,6 +126,12 @@ pref("browser.startup.upgradeDialog.enabled", false);
 pref("privacy.restrict3rdpartystorage.rollout.enabledByDefault", false);
 EOF
 });
+}
+
+sub disable_packagekit {
+    diag('Ensure packagekit is not interfering with zypper calls');
+    assert_script_run 'systemctl mask --now packagekit';
+    assert_script_run 'sudo -u bernhard gsettings set org.gnome.software download-updates false';
 }
 
 1;

--- a/tests/install/openqa_webui.pm
+++ b/tests/install/openqa_webui.pm
@@ -63,8 +63,7 @@ sub run {
     assert_screen "password-prompt";
     type_string $testapi::password . "\n";
     wait_still_screen(2);
-    diag('Ensure packagekit is not interfering with zypper calls');
-    assert_script_run('systemctl mask --now packagekit');
+    disable_packagekit;
     assert_script_run('zypper --no-cd -n in retry');
     if (check_var('OPENQA_FROM_GIT', 1)) {
         if (get_var('OPENQA_CONTAINERS')) {

--- a/tests/install/openqa_worker.pm
+++ b/tests/install/openqa_worker.pm
@@ -5,6 +5,7 @@ use utils;
 
 sub run {
     diag('worker setup');
+    disable_packagekit;
     assert_script_run('retry -s 30 -r 7 -- sh -c "zypper -n --gpg-auto-import-keys ref && zypper --no-cd -n in openQA-worker"', 3800);
     diag('Login once with fake authentication on openqa webUI to actually create preconfigured API keys for worker authentication');
     assert_script_run('curl http://localhost/login');

--- a/tests/update/zypper_up.pm
+++ b/tests/update/zypper_up.pm
@@ -11,7 +11,7 @@ sub run {
     assert_screen "password-prompt";
     type_string "1\n";
     wait_still_screen(2);
-    assert_script_run 'systemctl mask --now packagekit';
+    disable_packagekit;
     save_screenshot;
     clear_root_console;
     assert_script_run('retry -s 30 -- zypper -n up --auto-agree-with-licenses', timeout => 700, fail_message => 'zypper failed to update packages');


### PR DESCRIPTION
use common function for all tests disabling packagekit

And disable gnome-software download notifications to prevent displaying authorization dialog in gnome.

poo: https://progress.opensuse.org/issues/123496
vr: http://quasar.suse.cz/tests/2459