### PR TITLE
Handle "gnome-authentication-required" dialog

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -26,18 +26,24 @@ sub wait_for_desktop {
     if (match_has_tag('boot-menu')) {
         send_key 'ret';
     }
-    assert_screen 'openqa-desktop', 500;
-    if (match_has_tag('openqa-desktop-locked')) {
-        send_key 'esc';
-        wait_still_screen(1);
-        type_string $testapi::password . "\n";
-        assert_screen 'openqa-desktop';
-    }
-    elsif (match_has_tag('openqa-desktop-login')) {
-        assert_and_click 'openqa-desktop-login';
-        wait_still_screen(1);
-        type_string $testapi::password . "\n";
-        assert_screen 'openqa-desktop';
+    for (1..3) {
+        assert_screen 'openqa-desktop', 500;
+        if (match_has_tag('openqa-desktop-locked')) {
+            send_key 'esc';
+            wait_still_screen(1);
+            type_string $testapi::password . "\n";
+        }
+        elsif (match_has_tag('openqa-desktop-login')) {
+            assert_and_click 'openqa-desktop-login';
+            wait_still_screen(1);
+            type_string $testapi::password . "\n";
+        }
+        elsif (match_has_tag('openqa-desktop-gnome-auth-required')) {
+            assert_and_click 'openqa-desktop-gnome-auth-required';
+        }
+        else {
+            last;
+        }
     }
 }
 


### PR DESCRIPTION
Created needle in repository already matching the new additional tag
"openqa-desktop-gnome-auth-required".

Verification run:

```
 MARKDOWN=1 openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-openQA/pull/110 https://openqa.opensuse.org/tests/3161253
```

* [openqa-Tumbleweed-dev-x86_64-Build:TW.18921-openqa_install+publish@64bit-2G](https://openqa.opensuse.org/tests/3161380)

https://progress.opensuse.org/issues/123496