### PR TITLE
Load python test modules by default with new variable

### DIFF
--- a/main.pm
+++ b/main.pm
@@ -77,7 +77,7 @@ elsif (get_var('INSTALL')) {
 # testing from git only tests webui so far
 load_osautoinst_tests() unless check_var('OPENQA_FROM_GIT', 1);
 load_openQA_tests();
-load_python_tests() if get_var('PYTHON');
+load_python_tests() if get_var('LOAD_PYTHON_TEST_MODULES', 1);
 load_shutdown();
 
 1;


### PR DESCRIPTION
Instead of needing to explicitly specify python in the job templates we
should load python tests by default with a more explanatory variable
name while still offering to skip on problems.

This is inspired by
https://github.com/os-autoinst/os-autoinst-distri-openQA/pull/114/files#diff-093d7aec968469f705e116051d4161bd82c22f4add7145791e04e46101881fecR44
showing me that job templates need the explicit variable when it
shouldn't be necessary to reiterate that.