### PR TITLE
Fix usage of retry

### DIFF
--- a/tests/osautoinst/test_running.pm
+++ b/tests/osautoinst/test_running.pm
@@ -5,7 +5,7 @@ use utils;
 
 sub run {
     assert_script_run 'command -v ack >/dev/null || zypper --no-refresh -n in ack';
-    assert_script_run 'retry -s 30 -r 5 -- openqa-cli api jobs state=running state=done | ack --passthru --color "running|done"', 300;
+    assert_script_run q{retry -s 30 -r 5 -- sh -c 'openqa-cli api jobs state=running state=done | ack --passthru --color "running|done"'}, 300;
     save_screenshot;
     clear_root_console;
 }


### PR DESCRIPTION
The pipe to ack is not part of the actual command we want to test with retry, so it's always succeeding because openqa-cli always succeeds.

Issue: https://progress.opensuse.org/issues/131102

VR: https://openqa.opensuse.org/tests/3371821