### PR TITLE
t: Use consistent 'Mojo::Base' instead of strict+warnings

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -2,7 +2,6 @@ package utils;
 
 use Mojo::Base 'Exporter', -signatures;
 use Exporter;
-use strict;
 use testapi;
 use File::Basename qw(basename);
 

--- a/tests/containers/build.pm
+++ b/tests/containers/build.pm
@@ -1,5 +1,4 @@
-use strict;
-use base 'openQAcoretest';
+use Mojo::Base 'openQAcoretest';
 use testapi;
 
 sub run {

--- a/tests/install/boot.pm
+++ b/tests/install/boot.pm
@@ -1,5 +1,4 @@
-use strict;
-use base 'openQAcoretest';
+use Mojo::Base 'openQAcoretest';
 use utils;
 
 sub run {

--- a/tests/install/openqa_webui.pm
+++ b/tests/install/openqa_webui.pm
@@ -1,5 +1,4 @@
-use strict;
-use base 'openQAcoretest';
+use Mojo::Base 'openQAcoretest';
 use testapi;
 use utils;
 

--- a/tests/install/openqa_worker.pm
+++ b/tests/install/openqa_worker.pm
@@ -1,5 +1,4 @@
-use strict;
-use base 'openQAcoretest';
+use Mojo::Base 'openQAcoretest';
 use testapi;
 use utils;
 

--- a/tests/install/test_distribution.pm
+++ b/tests/install/test_distribution.pm
@@ -1,5 +1,4 @@
-use strict;
-use base 'openQAcoretest';
+use Mojo::Base 'openQAcoretest';
 use testapi;
 use utils;
 

--- a/tests/openQA/dashboard.pm
+++ b/tests/openQA/dashboard.pm
@@ -1,5 +1,4 @@
-use strict;
-use base 'openQAcoretest';
+use Mojo::Base 'openQAcoretest';
 use testapi;
 use utils;
 

--- a/tests/openQA/login.pm
+++ b/tests/openQA/login.pm
@@ -1,5 +1,4 @@
-use strict;
-use base 'openQAcoretest';
+use Mojo::Base 'openQAcoretest';
 use testapi;
 
 sub run {

--- a/tests/osautoinst/start_test.pm
+++ b/tests/osautoinst/start_test.pm
@@ -1,5 +1,4 @@
-use strict;
-use base 'openQAcoretest';
+use Mojo::Base 'openQAcoretest';
 use testapi;
 use utils;
 

--- a/tests/osautoinst/test_running.pm
+++ b/tests/osautoinst/test_running.pm
@@ -1,4 +1,3 @@
-use strict;
 use Mojo::Base 'openQAcoretest', -signatures;
 use testapi;
 use utils;

--- a/tests/osautoinst/worker.pm
+++ b/tests/osautoinst/worker.pm
@@ -1,5 +1,4 @@
-use strict;
-use base 'openQAcoretest';
+use Mojo::Base 'openQAcoretest';
 use testapi;
 use utils qw(wait_for_desktop switch_to_root_console clear_root_console);
 

--- a/tests/shutdown/shutdown.pm
+++ b/tests/shutdown/shutdown.pm
@@ -1,5 +1,4 @@
-use strict;
-use base 'openQAcoretest';
+use Mojo::Base 'openQAcoretest';
 use testapi;
 use utils qw(switch_to_root_console);
 


### PR DESCRIPTION
Same as suggested in our documentation we should use Mojo::Base
consistently in all openQA test modules.

Motivated by:
* https://github.com/os-autoinst/os-autoinst-distri-example/pull/28