### PR TITLE
Bump timeout for `os-autoinst-setup-multi-machine`

### DIFF
--- a/tests/install/openqa_webui.pm
+++ b/tests/install/openqa_webui.pm
@@ -39,7 +39,7 @@ sub install_from_repos {
 
 sub install_from_git {
     assert_script_run($_, 600) foreach (split /\n/, <<~'EOF');
-    retry -e -s 30 -- zypper -n in -C 'rubygem(sass)' git-core perl-App-cpanminus perl-Module-CPANfile perl-YAML-LibYAML postgresql-server apache2
+    retry -e -s 30 -- zypper -n in -C 'rubygem(sass)' git-core perl-App-cpanminus perl-Module-CPANfile perl-YAML-LibYAML postgresql-server apache2 npm
     systemctl start postgresql || systemctl status --no-pager postgresql
     su - postgres -c 'createuser root'
     su - postgres -c 'createdb -O root openqa'
@@ -47,6 +47,7 @@ sub install_from_git {
     cd openQA
     pkgs=$(for p in $(cpanfile-dump); do echo -n "perl($p) "; done); retry -e -s 30 -- zypper -n in -C $pkgs
     cpanm -nq --installdeps .
+    npm install
     for i in headers proxy proxy_http proxy_wstunnel rewrite ; do a2enmod $i ; done
     cp etc/apache2/vhosts.d/openqa-common.inc /etc/apache2/vhosts.d/
     sed "s/#ServerName.*$/ServerName $(hostname)/" etc/apache2/vhosts.d/openqa.conf.template > /etc/apache2/vhosts.d/openqa.conf

--- a/tests/install/openqa_worker.pm
+++ b/tests/install/openqa_worker.pm
@@ -20,7 +20,7 @@ EOF
         my $arch = get_required_var('ARCH');
         assert_script_run q{sed -i -e "s/\(\[global\]\)/\1\nWORKER_CLASS=qemu_}.$arch.q{,tap/" /etc/openqa/workers.ini};
     }
-    assert_script_run('os-autoinst-setup-multi-machine');
+    assert_script_run('os-autoinst-setup-multi-machine', timeout => 120);
     my $worker_setup = <<'EOF';
 systemctl status --no-pager os-autoinst-openvswitch
 systemctl enable --now openqa-worker@1


### PR DESCRIPTION
The default timeout of 90 seconds seems a little bit too short, see https://progress.opensuse.org/issues/155173#note-11. Adding 30 seconds should give us enough headroom to avoid running into timeouts. Note that in production we even have a timeout of 20 minutes just for starting `os-autoinst-openvswitch.service` but hopefully 2 minutes will be enough for our test setup.