### PR TITLE
Allow the post_fail_hook ip command to fail

### DIFF
--- a/lib/openQAcoretest.pm
+++ b/lib/openQAcoretest.pm
@@ -6,10 +6,10 @@ use utils qw(switch_to_root_console get_log);
 
 sub post_fail_hook ($self) {
     switch_to_root_console;
+    send_key 'ctrl-c';     # Stop current command, if any
     # we can't upload logs if the multimachine OVS bridge in the SUT has the same IP as the openQA-worker host
-    assert_script_run 'ip a del 10.0.2.2/15 dev br1';
+    script_run 'ip a del 10.0.2.2/15 dev br1'; # This may fail in case this IP is not actually set on the bridge
     if (get_var('OPENQA_FROM_GIT')) {
-        send_key 'ctrl-c';     # Stop current command, if any
         assert_script_run 'cd /root/openQA';
         enter_cmd 'script/openqa-cli api jobs';
         save_screenshot;

--- a/tests/install/openqa_webui.pm
+++ b/tests/install/openqa_webui.pm
@@ -56,7 +56,7 @@ sub install_from_git {
     EOF
     script_run('env OPENQA_CONFIG=etc/openqa nohup script/openqa daemon &', 0);
     diag('Wait until the server is responsive');
-    assert_script_run('while ! [ -f nohup.out ]; do sleep 1 ; done && grep -qP "Listening at.*(127.0.0.1|localhost)" <(tail -f -n0 nohup.out) ', 600);
+    assert_script_run('grep -qP "Listening at.*(127.0.0.1|localhost)" <(tail -F -n0 nohup.out) ', 600);
 }
 
 sub install_containers {

--- a/tests/osautoinst/test_running.pm
+++ b/tests/osautoinst/test_running.pm
@@ -7,7 +7,7 @@ sub run ($self) {
     if (get_var('FULL_MM_TEST')) {
         assert_script_run q{retry -s 30 -r 29 -- sh -c 'r=`openqa-cli api jobs test=ping_client | jq -r ".jobs | max_by(.id) | if .result != \"none\" then .result else .state end"`; echo $r | ack "incomplete|failed" && killall retry; echo $r | ack --passthru passed'}, 900;
         # we can't upload logs if the multimachine OVS bridge in the SUT has the same IP as the openQA-worker host
-        assert_script_run 'ip a del 10.0.2.2/15 dev br1';
+        script_run 'ip a del 10.0.2.2/15 dev br1'; # This may fail in case this IP is not actually set on the bridge
         $self->upload_mm_logs();
         get_log 'journalctl --pager-end --no-tail --no-pager -u apache2 -u nginx -u openqa-scheduler -u openqa-websockets -u openqa-webui -u openqa-worker@1' => 'openqa_services.log';
         get_log '(cat /var/lib/openqa/pool/1/autoinst-log.txt /var/lib/openqa/testresults/*/*/autoinst-log.txt ||:)' => 'autoinst-log.txt';


### PR DESCRIPTION
It may fail in case this IP is not actually set on the bridge.
Also the ctrl-c needs to happen before, because if the

    grep ... tail -f -n0 nohup.out
    
fails, it's not killed. Since ctrl-c shouldn't do any harm, I guess we can
do it regardless of which test we are running.

This ensures that the post_fail_hook can be completed.

Also this fixes sporadic failures in openqa_from_git: https://openqa.opensuse.org/tests/3946911#step/openqa_webui/36