### PR TITLE
Adjust timeout of container build calls to retry max

### DIFF
--- a/tests/containers/build.pm
+++ b/tests/containers/build.pm
@@ -2,9 +2,10 @@ use Mojo::Base 'openQAcoretest';
 use testapi;
 
 sub run {
-    assert_script_run('retry -s 30 -r 7 -e -- git clone https://github.com/os-autoinst/openQA.git', timeout => 300);
-    assert_script_run("retry -s 30 -r 7 -e -- docker build openQA/container/$_ -t openqa_$_", timeout => 3800) for qw(webui worker);
-    assert_script_run('retry -s 30 -r 7 -e -- docker build openQA/container/openqa_data -t openqa_data', timeout => 3800);
+    # The maximum of the retry is 3810 seconds
+    assert_script_run('retry -s 30 -r 7 -e -- git clone https://github.com/os-autoinst/openQA.git', timeout => 4000);
+    assert_script_run("retry -s 30 -r 7 -e -- docker build openQA/container/$_ -t openqa_$_", timeout => 4000) for qw(webui worker);
+    assert_script_run('retry -s 30 -r 7 -e -- docker build openQA/container/openqa_data -t openqa_data', timeout => 4000);
 }
 
 1;


### PR DESCRIPTION
The default timeout needs to be higher than the hypothetical maximum time of all retry attempts.

See: https://progress.opensuse.org/issues/160727