### PR TITLE
Ensure sufficient retry timeouts in install_from_git

### DIFF
--- a/tests/install/openqa_webui.pm
+++ b/tests/install/openqa_webui.pm
@@ -38,12 +38,13 @@ sub install_from_repos {
 }
 
 sub install_from_git {
+    install_packages(q/'rubygem(sass)' git-core perl-App-cpanminus perl-Module-CPANfile perl-YAML-LibYAML postgresql-server apache2 npm/);
+    # The maximum of the retry is 3810 seconds
+    assert_script_run('retry -e -s 30 -r 7 -- git clone https://github.com/os-autoinst/openQA.git', timeout => 4000);
     assert_script_run($_, 600) foreach (split /\n/, <<~'EOF');
-    retry -e -s 30 -- zypper -n in -C 'rubygem(sass)' git-core perl-App-cpanminus perl-Module-CPANfile perl-YAML-LibYAML postgresql-server apache2 npm
     systemctl start postgresql || systemctl status --no-pager postgresql
     su - postgres -c 'createuser root'
     su - postgres -c 'createdb -O root openqa'
-    retry -e -s 30 -r 7 -- git clone https://github.com/os-autoinst/openQA.git
     cd openQA
     pkgs=$(for p in $(cpanfile-dump); do echo -n "perl($p) "; done); retry -e -s 30 -- zypper -n in -C $pkgs
     cpanm -nq --installdeps .


### PR DESCRIPTION
The individual calls of the "script" need to consider the timeout for retry. Using install_packages already considers that. Cloning also requires a higher timeout.

See: https://progress.opensuse.org/issues/160727