### PR TITLE
Improve waiting for webserver

### DIFF
--- a/tests/install/openqa_webui.pm
+++ b/tests/install/openqa_webui.pm
@@ -1,6 +1,6 @@
 use Mojo::Base 'openQAcoretest';
 use testapi;
-use utils;
+use utils qw(install_packages get_log clear_root_console);
 
 
 sub install_from_repos {
@@ -57,7 +57,8 @@ sub install_from_git {
     EOF
     script_run('env OPENQA_CONFIG=etc/openqa nohup script/openqa daemon &', 0);
     diag('Wait until the server is responsive');
-    assert_script_run('grep -qP "Listening at.*(127.0.0.1|localhost)" <(tail -F -n0 nohup.out) ', 600);
+    assert_script_run('grep -qP "Listening at.*(127.0.0.1|localhost)" <(tail -F nohup.out) ', 600);
+    get_log 'cat nohup.out' => 'openqa_nohup_out.txt';
 }
 
 sub install_containers {


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/162311

The tail/grep seems to happen so late that the nohup.out already exists with the expected content and -n0 would then miss it. I see no problem to not restrict the tail here.
Also the test now uploads the log always. That can help comparing passing and failed tests.

Note: I created this PR directly from our new codespace!