### PR TITLE
Upload log with .txt suffix

### DIFF
--- a/lib/openQAcoretest.pm
+++ b/lib/openQAcoretest.pm
@@ -14,13 +14,13 @@ sub post_fail_hook ($self) {
         enter_cmd 'script/openqa-cli api jobs';
         save_screenshot;
         enter_cmd 'which sass';
-        get_log 'journalctl --pager-end --no-tail --no-pager -u apache2 -u nginx' => 'openqa_services.log';
+        get_log 'journalctl --pager-end --no-tail --no-pager -u apache2 -u nginx' => 'openqa_services.log.txt';
         get_log 'cat nohup.out'                                                   => 'openqa_nohup_out.txt';
     }
     else {
         enter_cmd 'openqa-cli api jobs';
         save_screenshot;
-        get_log 'journalctl --pager-end --no-tail --no-pager -u apache2 -u nginx -u openqa-scheduler -u openqa-websockets -u openqa-webui -u openqa-worker@1' => 'openqa_services.log';
+        get_log 'journalctl --pager-end --no-tail --no-pager -u apache2 -u nginx -u openqa-scheduler -u openqa-websockets -u openqa-webui -u openqa-worker@1' => 'openqa_services.log.txt';
         get_log '(cat /var/lib/openqa/pool/1/autoinst-log.txt /var/lib/openqa/testresults/*/*/autoinst-log.txt ||:)' => 'autoinst-log.txt';
     }
 }


### PR DESCRIPTION
This way openQA will display it directly instead of downloading it.

Related issue: https://progress.opensuse.org/issues/162311