### PR TITLE
Fix display of logfile 'cpuinfo'

### DIFF
--- a/tests/osautoinst/test_running.pm
+++ b/tests/osautoinst/test_running.pm
@@ -29,7 +29,7 @@ sub post_fail_hook ($self) {
     $self->SUPER::post_fail_hook;
     script_run 'lsmod | grep kvm';
     save_screenshot;
-    get_log('grep --color -z -E "(vmx|svm)" /proc/cpuinfo' => 'cpuinfo');
+    get_log('grep --color -z -E "(vmx|svm)" /proc/cpuinfo' => 'cpuinfo.txt');
     assert_script_run 'grep --color -z -E "(vmx|svm)" /proc/cpuinfo', fail_message => 'Machine does not support nested virtualization, please enable in worker host';
     $self->upload_mm_logs() if get_var('FULL_MM_TEST');
 }


### PR DESCRIPTION
A browser on the openQA web UI views can directly display files with
extension .txt so we should upload cpuinfo output as such. This fixes
the problem that the cpuinfo file as uploaded by the post_fail_hook
needs to be downloaded and explicitly opened as text file whereas it
could be viewed directly in the browser.