### PR TITLE
Ensure to use current bootstrap from devel:openQA

### DIFF
--- a/tests/install/openqa_webui.pm
+++ b/tests/install/openqa_webui.pm
@@ -83,7 +83,7 @@ sub install_from_bootstrap {
 }
 
 sub run {
-    add_repo if get_var('ADD_OPENQA_REPO', !get_var('OPENQA_FROM_GIT') && !get_var('OPENQA_FROM_BOOTSTRAP'));
+    add_repo if get_var('ADD_OPENQA_REPO', !get_var('OPENQA_FROM_GIT'));
     if (get_var('OPENQA_FROM_GIT')) {
         if (get_var('OPENQA_CONTAINERS')) {
             install_containers;


### PR DESCRIPTION
openqa-bootstrap was intended to be super-simple and allow to install
openQA without needing any further preparation steps.but as the real
world shows there can still be bugs :) In that we need to use the actual
current version of openqa-bootstrap from devel:openQA with potential
fixes otherwise we would always need manual handling to bring in fixes
to openqa-bootstrap.

This commit adds the devel:openQA repo(s) also in the case of installing
from bootstrap to fix the above problem. The only minor downside is that
we don't test openqa-bootstrap anymore when devel:openQA is not already
added to the system.

Related progress issue: https://progress.opensuse.org/issues/164940