### PR TITLE
Also upload system logs to find other errors

### DIFF
--- a/lib/openQAcoretest.pm
+++ b/lib/openQAcoretest.pm
@@ -28,6 +28,7 @@ sub test_flags { {fatal => 1} }
 
 sub upload_openqa_logs {
     get_log 'journalctl --pager-end --no-tail --no-pager -u apache2 -u nginx -u openqa-scheduler -u openqa-websockets -u openqa-webui -u openqa-gru -u openqa-worker@1' => 'openqa_services.log.txt';
+    get_log 'journalctl --pager-end --no-tail --no-pager' => 'journal.log.txt';
     chomp(my @logs = qx{find /var/lib/openqa/pool/1/autoinst-log.txt /var/lib/openqa/testresults/*/*/autoinst-log.txt});
     @logs and get_log "(cat @logs ||:)" => 'autoinst-log.txt';
     get_log '(find /var/lib/openqa/pool/ /var/lib/openqa/testresults/ ||:)' => 'find.txt';


### PR DESCRIPTION
Recently we observed a problem with the os-autoinst-openvswitch service.
While the relevant system journal content was shown in screenshots it
was not uploaded in an easy to process log file so I am adding another
call to also upload the complete system journal which should not be that
big on those clean test OS installations.