### PR TITLE
Implement module to validate Autoyast template profiles

### DIFF
--- a/main.pm
+++ b/main.pm
@@ -24,6 +24,7 @@ sub load_install_tests() {
     # interaction
     return 1 if get_var('OPENQA_FROM_GIT');
     loadtest 'install/openqa_worker' unless get_var('OPENQA_FROM_BOOTSTRAP');
+    loadtest 'install/worker_ay_validation' if get_var('VALIDATE_AUTOYAST');
     loadtest 'install/test_distribution';
 }
 

--- a/tests/install/worker_ay_validation.pm
+++ b/tests/install/worker_ay_validation.pm
@@ -1,0 +1,22 @@
+use Mojo::Base 'openQAcoretest';
+use File::Basename;
+use testapi;
+use utils;
+
+sub run {
+    switch_to_root_console;
+    my $profile = '/root/result.xml';
+    install_packages('autoyast2 libxml2-tools');
+    my $template_path = get_required_var('AUTOYAST');
+    my $profile_template = basename($template_path);
+    assert_script_run "wget $template_path";
+    # run-scripts=true is not used because the salt-minion is not installed in the VM
+    enter_cmd "yast2 autoyast check-profile filename=$profile_template output=$profile run-erb=true";
+    assert_screen "check-autoyast-profile-ok", timeout => 300;
+    clear_root_console;
+    assert_script_run "xmllint $profile", fail_message => "generated profile '$profile' does not pass validation";
+    upload_logs $profile;
+    clear_root_console;
+}
+
+1;


### PR DESCRIPTION
With the use of the test variable AUTOYAST we can pass a erb profile tfor validation. The module exercises the happy path. Meaning that it checks only one screen which it comes at the end of the validation of `yast2 autoyast check-profile`. For any warning or error, yast will throw a popup and the test should fail.

https://progress.opensuse.org/issues/156169