### PR TITLE
Add option to enforce AppArmor profiles in tests

### DIFF
--- a/main.pm
+++ b/main.pm
@@ -25,6 +25,7 @@ sub load_install_tests() {
     return 1 if get_var('OPENQA_FROM_GIT');
     loadtest 'install/openqa_worker' unless get_var('OPENQA_FROM_BOOTSTRAP');
     loadtest 'install/worker_ay_validation' if get_var('VALIDATE_AUTOYAST');
+    loadtest 'install/apparmor' if get_var('USE_APPARMOR');
     loadtest 'install/test_distribution';
 }
 

--- a/scenario-definitions.yaml
+++ b/scenario-definitions.yaml
@@ -55,6 +55,7 @@ job_templates:
     settings:
       DESKTOP: minimalx
       OPENQA_WEB_PROXY: 'nginx'
+      USE_APPARMOR: "1"
   openqa_install_multimachine:
     <<: *common_4g
     settings:

--- a/tests/install/apparmor.pm
+++ b/tests/install/apparmor.pm
@@ -1,0 +1,17 @@
+use Mojo::Base 'openQAcoretest', -signatures;
+use testapi;
+use utils qw(install_packages);
+
+sub run {
+    # Make sure AppArmor is installed and enabled
+    install_packages('-t pattern apparmor');
+    assert_script_run('systemctl enable --now apparmor');
+    assert_script_run('aa-enabled');
+    # Reload AppArmor to enforce newly installed profiles
+    assert_script_run('systemctl reload apparmor');
+    # Restart running services to apply loaded profiles
+    assert_script_run('systemctl try-restart openqa-*');
+    assert_script_run('aa-status --filter.profiles="usr.share.openqa.*"');
+}
+
+1;


### PR DESCRIPTION
Introduce variable `USE_APPARMOR` to allow enforcing AppArmor profiles inside tests. Use the new variable inside nginx install variant of the test.

This needs https://github.com/os-autoinst/openQA/pull/5883 first, otherwise the inner test will not pass.

Reference: https://progress.opensuse.org/issues/155413


Validation run (currently expected to fail): https://openqa.opensuse.org/tests/4423875