### PR TITLE
Upload audit log when test fails with USE_APPARMOR

### DIFF
--- a/lib/openQAcoretest.pm
+++ b/lib/openQAcoretest.pm
@@ -21,6 +21,7 @@ sub post_fail_hook ($self) {
         save_screenshot;
         $self->upload_openqa_logs;
     }
+    get_log 'cat /var/log/audit/audit.log' => 'audit.log.txt' if get_var('USE_APPARMOR');
 }
 
 # All steps belonging to core openQA functionality are 'fatal'. by default


### PR DESCRIPTION
To help debugging AppArmor related issues, upload audit.log during post fail hook when USE_APPARMOR is enabled (i.e. when AppArmor rules are enforced).

Reference: https://progress.opensuse.org/issues/155413