### PR TITLE
Consider more builds when looking for published snapshot

### DIFF
--- a/.github/workflows/openqa.yml
+++ b/.github/workflows/openqa.yml
@@ -26,8 +26,8 @@ jobs:
         run: >-
           echo build=$(openqa-cli api
           --host ${OPENQA_HOST:-https://openqa.opensuse.org}
-          job_groups/${OPENQA_GROUP_ID:-1}/build_results limit_builds=1 only_tagged=1
-          | jq -r '[ .build_results[] | select(.tag.description=="published") | .build ][]'
+          job_groups/${OPENQA_GROUP_ID:-1}/build_results only_tagged=1
+          | jq -r '[ .build_results[] | select(.tag.description=="published") | .build ][0]'
           ) >> "$GITHUB_OUTPUT"
       - name: Link to test result overview page
         run: >-


### PR DESCRIPTION
Instead of filtering the builds to 1 and then
assuming we can select "published" from that list
this commit changes the lookup to read the default
number of builds, which is by default 10, and then
selects the latest published.

References:
 * https://progress.opensuse.org/issues/165722
 * https://github.com/os-autoinst/os-autoinst-distri-opensuse/commit/25990294235f729d866d4a140aa21a8effebcc17

This should fix the test issue in #200 