### PR TITLE
Make timeout for try-restart longer

### DIFF
--- a/tests/install/apparmor.pm
+++ b/tests/install/apparmor.pm
@@ -10,7 +10,7 @@ sub run {
     # Reload AppArmor to enforce newly installed profiles
     assert_script_run('systemctl reload apparmor');
     # Restart running services to apply loaded profiles
-    assert_script_run('systemctl try-restart openqa-*');
+    assert_script_run('systemctl try-restart openqa-*', timeout => 300);
     assert_script_run('aa-status --filter.profiles="usr.share.openqa.*"');
 }
 


### PR DESCRIPTION
Sometimes it takes a longer time to restart all services and reload AppArmor profiles. Make the timeout longer.

Reference: https://progress.opensuse.org/issues/155413