### PR TITLE
Make test more stable by staying on the current page

### DIFF
--- a/tests/openQA/tests.pm
+++ b/tests/openQA/tests.pm
@@ -7,7 +7,6 @@ sub run {
     send_key_until_needlematch 'openqa-scheduled-test', 'down';
     assert_and_click 'openqa-scheduled-test';
     assert_screen 'openqa-test-details';
-    assert_and_click 'openqa-all-tests';
 }
 
 1;


### PR DESCRIPTION
Sometimes it take too long to load the new page and focus in the search bar can be lost upon page load. The search bar work on the current page as well so there is no need to visit all tests page.