### PR TITLE
Handle docker build failures

### DIFF
--- a/tests/containers/build.pm
+++ b/tests/containers/build.pm
@@ -13,6 +13,8 @@ sub post_fail_hook ($self) {
     upload_logs 'docker_build.txt';
     my $log = script_output('cat docker_build.txt');
     record_info('docker build', $log, result => 'fail');
+    record_info('poo#165992', 'Valid metadata not found at specified URL: https://progress.opensuse.org/issues/165992', result => 'fail')
+        if $log =~ m/Valid metadata not found at specified URL/;
     $self->SUPER::post_fail_hook;
 }
 

--- a/tests/containers/build.pm
+++ b/tests/containers/build.pm
@@ -11,6 +11,8 @@ sub run {
 sub post_fail_hook ($self) {
     save_screenshot;
     upload_logs 'docker_build.txt';
+    my $log = script_output('cat docker_build.txt');
+    record_info('docker build', $log, result => 'fail');
     $self->SUPER::post_fail_hook;
 }
 

--- a/tests/containers/build.pm
+++ b/tests/containers/build.pm
@@ -1,11 +1,17 @@
-use Mojo::Base 'openQAcoretest';
+use Mojo::Base 'openQAcoretest', -signatures;
 use testapi;
 
 sub run {
     # The maximum of the retry is 3810 seconds
     assert_script_run('retry -s 30 -r 7 -e -- git clone https://github.com/os-autoinst/openQA.git', timeout => 4000);
-    assert_script_run("retry -s 30 -r 7 -e -- docker build openQA/container/$_ -t openqa_$_", timeout => 4000) for qw(webui worker);
-    assert_script_run('retry -s 30 -r 7 -e -- docker build openQA/container/openqa_data -t openqa_data', timeout => 4000);
+    assert_script_run("retry -s 30 -r 7 -e -- bash -o pipefail -c 'docker build openQA/container/$_ -t openqa_$_ --progress=plain 2>&1 | tee docker_build.txt'", timeout => 4000) for qw(webui worker);
+    assert_script_run("retry -s 30 -r 7 -e -- bash -o pipefail -c 'docker build openQA/container/openqa_data -t openqa_data --progress=plain 2>&1 | tee docker_build.txt'", timeout => 4000);
+}
+
+sub post_fail_hook ($self) {
+    save_screenshot;
+    upload_logs 'docker_build.txt';
+    $self->SUPER::post_fail_hook;
 }
 
 1;


### PR DESCRIPTION
Upload docker logs when the build fails, make docker build logs available for auto review, detect and reference poo#165992 if applicable.

Reference: https://progress.opensuse.org/issues/165992