### PR TITLE
Remove leading slash from script name

### DIFF
--- a/main.pm
+++ b/main.pm
@@ -13,7 +13,7 @@ $testapi::password //= 'nots3cr3t';
 
 sub loadtest ($test) {
     my $filename = $test =~ /\.p[my]$/ ? $test : $test . '.pm';
-    autotest::loadtest("/tests/$filename");
+    autotest::loadtest("tests/$filename");
 }
 
 sub load_install_tests() {


### PR DESCRIPTION
It is not needed and creates a confusing double slash for source view links

Issue: https://progress.opensuse.org/issues/167971