### PR TITLE
Ensure test_running-testresults.tar.gz contains image files

### DIFF
--- a/lib/openQAcoretest.pm
+++ b/lib/openQAcoretest.pm
@@ -34,7 +34,7 @@ sub upload_openqa_logs {
     my @logs = split m/\n/, script_output q{find /var/lib/openqa -name autoinst-log.txt};
     @logs and get_log "(cat @logs ||:)" => 'autoinst-log.txt';
     get_log '(find /var/lib/openqa/pool/ /var/lib/openqa/testresults/ ||:)' => 'find.txt';
-    assert_script_run 'tar -cvzf testresults.tar.gz /var/lib/openqa/testresults/';
+    script_run 'tar -cvzhf testresults.tar.gz /var/lib/openqa/testresults/';
     upload_logs 'testresults.tar.gz';
     get_log q|sudo -u geekotest /usr/share/openqa/script/openqa eval -V 'my $jobs = app->minion->jobs; my @r; while (my $j = $jobs->next) { push @r, $j->{result} }; \@r'| => 'openqa_minion_results.txt';
     get_log q{openqa-cli api jobs | jq .} => 'openqa-api-jobs.json';


### PR DESCRIPTION
files in testresults.tar.gz are not opening, likely because are symbolic links. Ensure that the tar contains the actual files and can be accessed. For that tar takes `-h` option which comes with some caveats. As such the assert_script_run is replaced by script_run. The reason is that it can fail due to broken links or circular references.

https://progress.opensuse.org/issues/169249