### PR TITLE
Remove useless double screen check

### DIFF
--- a/tests/openQA/dashboard.pm
+++ b/tests/openQA/dashboard.pm
@@ -9,12 +9,7 @@ sub run {
     switch_to_x11;
     ensure_unlocked_desktop();
     start_gui_program('firefox http://localhost', 60, valid => 1);
-    # starting from git might take a bit longer to get and generated assets
-    # workaround for poo#19798, basically doubles the timeout
-    if ((check_screen 'openqa-dashboard', 180) == undef) {
-        record_soft_failure 'ff took to long to start';
-    }
     #wait few minutes for ff to start and then fail the test
-    assert_screen 'openqa-dashboard', 360;
+    assert_screen 'openqa-dashboard', 600;
 }
 1;


### PR DESCRIPTION
Instead of a check_screen and then checking for the same screen again we
should only do one screen check. This also removes the unreferenced
record_soft_failure which should be avoided as well as prevents a
warning about comparison with undefined variable.