### PR TITLE
Ensure curl fails when checking the login works in worker test

### DIFF
--- a/tests/install/openqa_worker.pm
+++ b/tests/install/openqa_worker.pm
@@ -6,7 +6,7 @@ sub run {
     diag('worker setup');
     install_packages('openQA-worker', 3800);
     diag('Login once with fake authentication on openqa webUI to actually create preconfigured API keys for worker authentication');
-    assert_script_run('curl http://localhost/login');
+    assert_script_run('curl --fail-with-body http://localhost/login');
     diag('adding temporary, preconfigured API keys to worker config');
     type_string('cat >> /etc/openqa/client.conf <<EOF
 [localhost]


### PR DESCRIPTION
Otherwise an error page is printed and the test continues.

See: https://progress.opensuse.org/issues/178642