### PR TITLE
Verify web UI works via curl after installation

### DIFF
--- a/tests/install/openqa_webui.pm
+++ b/tests/install/openqa_webui.pm
@@ -100,6 +100,10 @@ sub run {
     else {
         install_from_pkgs;
     }
+    unless (get_var('OPENQA_CONTAINERS')) {
+        # Verify that the web UI is available after installation
+        assert_script_run('curl --fail-with-body http://localhost/login');
+    }
     save_screenshot;
     clear_root_console;
 }


### PR DESCRIPTION
Existing listening checks and systemd status only confirm that a web server is running.

See: https://progress.opensuse.org/issues/178642