### PR TITLE
Upload audit log also for SELinux cases

### DIFF
--- a/lib/openQAcoretest.pm
+++ b/lib/openQAcoretest.pm
@@ -21,7 +21,7 @@ sub post_fail_hook ($self) {
         save_screenshot;
         $self->upload_openqa_logs;
     }
-    get_log 'cat /var/log/audit/audit.log' => 'audit.log.txt' if get_var('USE_APPARMOR');
+    get_log 'cat /var/log/audit/audit.log' => 'audit.log.txt';
 }
 
 # All steps belonging to core openQA functionality are 'fatal'. by default


### PR DESCRIPTION
Same as for apparmor also SELinux uses audit.log so uploading that can
help us to debug if application calls are denied.

Related progress issue: https://progress.opensuse.org/issues/178822