### PR TITLE
Revert "Disable selinux as a temporary workaround"

### DIFF
--- a/tests/install/prepare.pm
+++ b/tests/install/prepare.pm
@@ -5,6 +5,9 @@ use utils qw(login disable_packagekit switch_to_root_console);
 sub run {
     login;
 
+    # SELinux: allow web proxy to connect to openQA backend
+    assert_script_run('semanage boolean -m -1 httpd_can_network_connect');
+
     disable_packagekit;
     assert_script_run('for i in {1..7}; do zypper --no-cd -n in retry && break; sleep $((i**2*20)); done');
     assert_script_run('zypper --no-cd -n rm xscreensaver');

--- a/tests/install/prepare.pm
+++ b/tests/install/prepare.pm
@@ -5,9 +5,6 @@ use utils qw(login disable_packagekit switch_to_root_console);
 sub run {
     login;
 
-    # Temorary workaround for selinux https://progress.opensuse.org/issues/178822
-    assert_script_run('semanage permissive -a httpd_t');
-
     disable_packagekit;
     assert_script_run('for i in {1..7}; do zypper --no-cd -n in retry && break; sleep $((i**2*20)); done');
     assert_script_run('zypper --no-cd -n rm xscreensaver');


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-openQA#229

Ticket: https://progress.opensuse.org/issues/178822


Shouldn't be needed anymore as https://github.com/os-autoinst/openQA/pull/6313 is merged