### PR TITLE
Fix error 403 when accessing dashboard & re-enable Nginx

### DIFF
--- a/scenario-definitions.yaml
+++ b/scenario-definitions.yaml
@@ -52,15 +52,12 @@ job_templates:
       OPENQA_FROM_BOOTSTRAP: "1"
       AUTOYAST: "https://raw.githubusercontent.com/os-autoinst/openQA/master/contrib/ay-openqa-worker.xml.erb"
       VALIDATE_AUTOYAST: "1"
-  # Temporarily disable openqa_install_nginx
-  # https://progress.opensuse.org/issues/180002
-  # https://github.com/os-autoinst/os-autoinst-distri-openQA/pull/235
-  # openqa_install_nginx:
-  #   <<: *common
-  #   settings:
-  #     DESKTOP: minimalx
-  #     OPENQA_WEB_PROXY: 'nginx'
-  #     USE_APPARMOR: "1"
+  openqa_install_nginx:
+    <<: *common
+    settings:
+      DESKTOP: minimalx
+      OPENQA_WEB_PROXY: 'nginx'
+      USE_APPARMOR: "1"
   openqa_install_multimachine:
     <<: *common_4g
     settings:

--- a/tests/openQA/dashboard.pm
+++ b/tests/openQA/dashboard.pm
@@ -8,7 +8,7 @@ sub run {
     prepare_firefox_autoconfig;
     switch_to_x11;
     ensure_unlocked_desktop();
-    start_gui_program('firefox http://localhost', 60, valid => 1);
+    start_gui_program('firefox http://127.0.0.1', 60, valid => 1);
     #wait few minutes for ff to start and then fail the test
     assert_screen 'openqa-dashboard', 600;
 }


### PR DESCRIPTION
https://progress.opensuse.org/issues/180002#note-19

Verification runs:
- Apache2: https://openqa.opensuse.org/tests/4995318
- Nginx: https://openqa.opensuse.org/tests/4995439