### PR TITLE
Fix adjusting firefox config

### DIFF
--- a/tests/openQA/dashboard.pm
+++ b/tests/openQA/dashboard.pm
@@ -5,6 +5,7 @@ use utils;
 use OpenQA::Wheel::Launcher 'start_gui_program';
 
 sub run {
+    switch_to_root_console;
     prepare_firefox_autoconfig;
     switch_to_x11;
     ensure_unlocked_desktop();


### PR DESCRIPTION
"prepare_firefox_autoconfig" needs a text terminal to type into. It
seems at some time in the past a regression was introduced that the
firefox config is not typed into a text terminal anymore after any
previous test module did not end up on the text terminal anymore.

This fixes the entering of configuration by explicitly switching to the
root console. This should fix the sporadic issue of firefox asking in a
first-time wizard of confirmation instead of showing the selected page
that the openQA test expects.

Related progress issue: https://progress.opensuse.org/issues/181187