### PR TITLE
Fix dashboard access on nginx

### DIFF
--- a/tests/install/openqa_webui.pm
+++ b/tests/install/openqa_webui.pm
@@ -28,6 +28,7 @@ sub install_from_pkgs {
     assert_script_run "/usr/share/openqa/script/configure-web-proxy $proxy_args";
     if (check_var('OPENQA_WEB_PROXY', 'nginx')) {
         assert_script_run 'systemctl disable --now apache2';
+        assert_script_run 'sed -i "/server_name/ s/localhost/_/" /etc/nginx/nginx.conf';
         assert_script_run 'systemctl enable nginx';
         assert_script_run 'systemctl restart nginx';
     }

--- a/tests/openQA/dashboard.pm
+++ b/tests/openQA/dashboard.pm
@@ -8,8 +8,11 @@ sub run {
     prepare_firefox_autoconfig;
     switch_to_x11;
     ensure_unlocked_desktop();
+    start_gui_program('firefox http://localhost', 60, valid => 1);
+    assert_screen 'openqa-dashboard', 60;
     start_gui_program('firefox http://127.0.0.1', 60, valid => 1);
-    #wait few minutes for ff to start and then fail the test
-    assert_screen 'openqa-dashboard', 600;
+    assert_screen 'openqa-dashboard', 60;
+    start_gui_program('firefox http://[::1]', 60, valid => 1);
+    assert_screen 'openqa-dashboard', 60;
 }
 1;


### PR DESCRIPTION
https://progress.opensuse.org/issues/180002

Change the default nginx configuration so the dashboard can be accessed from `localhost` as well as an IP address. The test coverage is also expanded to include all options for accessing the dashboard.

Verification run: https://openqa.opensuse.org/tests/5035573