### PR TITLE
Avoid failures in `start_test` if o3 is temporarily offline/slow

### DIFF
--- a/tests/osautoinst/start_test.pm
+++ b/tests/osautoinst/start_test.pm
@@ -8,27 +8,27 @@ sub fetch_job_id($groupid, $ttest, $flavor, $openqa_url) {
     my $cmd = <<"EOF";
 set -o pipefail
 zypper -n in jq
-resp=\$(OPENQA_CLI_RETRIES=5 openqa-cli api --host $openqa_url jobs version=Tumbleweed scope=relevant arch='$arch' flavor=$flavor test='$ttest' groupid=$groupid latest=1)
+resp=\$(OPENQA_CLI_RETRIES=6 OPENQA_CLI_RETRY_FACTOR=2 openqa-cli api --host $openqa_url jobs version=Tumbleweed scope=relevant arch='$arch' flavor=$flavor test='$ttest' groupid=$groupid latest=1)
 job_id=\$(echo "\$resp" | jq -r '.jobs | map(select(.result == "passed")) | max_by(.settings.BUILD) .id')
 echo "Job ID: \$job_id"
 if [ -z \$job_id  ]; then echo "Unable to find a suitable job to clone from o3. The API query returned: \$resp" && false; fi
 echo "Scenario: $arch-$ttest-$flavor: \$job_id"
 EOF
-    assert_script_run($_) foreach (split /\n/, $cmd);
+    assert_script_run($_, $_ =~ m/openqa-cli/ ? (timeout => 300) : ()) foreach (split /\n/, $cmd);
 }
 
 sub full_run {
     # clone the latest "minimalx" job for the most recent Tumbleweed build with matching architecture
     my $openqa_url = get_var('OPENQA_HOST', 'https://openqa.opensuse.org');
     fetch_job_id(1, 'minimalx', 'NET', $openqa_url);
-    assert_script_run("retry -e -- openqa-clone-job --show-progress --from $openqa_url \$job_id", timeout => 120);
+    assert_script_run("retry -r 5 -e -- openqa-clone-job --show-progress --from $openqa_url \$job_id", timeout => 300);
 }
 
 sub full_run_multimachine {
     # clone the latest "ping_client" MM job for the most recent Tumbleweed build with matching architecture
     my $openqa_url = get_var('OPENQA_HOST', 'https://openqa.opensuse.org');
     fetch_job_id(1, 'ping_client', 'DVD', $openqa_url);
-    assert_script_run("retry -e -- openqa-clone-job --show-progress --skip-chained-deps --from $openqa_url \$job_id", timeout => 600);
+    assert_script_run("retry -r 5 -e -- openqa-clone-job --show-progress --skip-chained-deps --from $openqa_url \$job_id", timeout => 600);
 }
 
 sub example_run {


### PR DESCRIPTION
* Use exponential backoff when calling `openqa-cli` to find a job to clone
* Bump number of retires and timeouts to be a bit more patient in general
* See https://progress.opensuse.org/issues/184025