### PR TITLE
Prevent worker to fail on missing key and secret keys

### DIFF
--- a/tests/containers/single_container_webui.pm
+++ b/tests/containers/single_container_webui.pm
@@ -12,7 +12,7 @@ sub run {
   wait_for_container_log('openqa_webui', 'Web application available at', 'docker');
 
   assert_script_run('curl http://localhost');
-  assert_script_run('docker rm -f openqa_webui');
+  #assert_script_run('docker rm -f openqa_webui');
 }
 
 sub post_fail_hook {

--- a/tests/containers/worker.pm
+++ b/tests/containers/worker.pm
@@ -3,10 +3,40 @@ use testapi;
 use utils;
 
 sub run {
-  my $volumes = '-v "/root/data/factory:/data/factory" -v "/root/data/tests:/data/tests" -v "/root/openQA/container/openqa_data/data.template/conf/:/data/conf:ro"';
-  assert_script_run("docker run -d --network testing $volumes --name openqa_worker openqa_worker");
-  wait_for_container_log('openqa_worker', 'API key and secret are needed', 'docker');
-  clear_root_console;
+    #my $apikey = '1234567890ABCDEF';
+    #my $apikey = '1234567890ABCDEF';
+    my $volumes = '-v "/root/data/factory:/data/factory" -v "/root/data/tests:/data/tests" -v "/root/openQA/container/openqa_data/data.template/conf/:/data/conf:ro"';
+    script_output(
+        "echo  \"\$(cat <<EOF
+[openqa_webui]
+key = 1234567890ABCDEF
+secret = 1234567890ABCDEF
+
+[localhost]
+key = 1234567890ABCDEF
+secret = 1234567890ABCDEF
+EOF
+        )\"  > /root/openQA/container/openqa_data/data.template/conf/client.conf"
+	);
+    script_output(
+        "echo  \"\$(cat <<EOF
+[global]
+BACKEND = qemu
+HOST = http://openqa_webui
+WORKER_HOSTNAME = openqa_worker
+EOF
+        )\"  > /root/openQA/container/openqa_data/data.template/conf/workers.ini"
+	);
+    assert_script_run("docker run -d --network testing $volumes --name openqa_worker openqa_worker");
+    my $expected_log = 'Failed to register';
+    wait_for_container_log('openqa_worker', 'Failed to register', 'docker');
+    record_soft_failure("$expected_log - https://progress.opensuse.org/issues/186651");
+    clear_root_console;
+}
+
+sub post_run_hook {
+  script_run('docker rm -f openqa_worker');
+  script_run('docker rm -f openqa_webui');
 }
 
 1;


### PR DESCRIPTION
The worker still fails but not due to misconfuration. But this time will throw an additional soft fail to make visible the issue with the containers' communication.

poo: https://progress.opensuse.org/issues/186651