### PR TITLE
Optimize visit_tests and Fix race-condition

### DIFF
--- a/tests/openQA/tests.pm
+++ b/tests/openQA/tests.pm
@@ -5,7 +5,7 @@ use utils;
 sub visit_test($needle) {
     assert_and_click 'openqa-all-tests';
     send_key_until_needlematch $needle, 'down';
-    assert_and_click $needle;
+    click_lastmatch;
     assert_screen 'openqa-test-details';
     assert_and_click 'openqa-logo';
     assert_screen 'openqa-dashboard';

--- a/tests/openQA/tests.pm
+++ b/tests/openQA/tests.pm
@@ -4,7 +4,7 @@ use utils;
 
 sub visit_test($needle) {
     assert_and_click 'openqa-all-tests';
-    send_key_until_needlematch $needle, 'down';
+    send_key_until_needlematch $needle, 'end';
     click_lastmatch;
     assert_screen 'openqa-test-details';
     assert_and_click 'openqa-logo';


### PR DESCRIPTION
* Try to avoid race condition in "visit_test" with "end" key
* Optimize "visit_test" with "click_lastmatch"

Verification:
* before: https://openqa.opensuse.org/tests/overview?build=%3ATW.38926-poo188043-okurz-before&distri=openqa&version=Tumbleweed 200/200 (100%) passed, so the original issue is not easily reproducible
* after: https://openqa.opensuse.org/tests/overview?build=%3ATW.38926-poo188043-okurz-pr251&distri=openqa&version=Tumbleweed 200/200 (100%) passed, proof that we don't have introduced a significant regression