### PR TITLE
Simplify workflow

### DIFF
--- a/.github/workflows/openqa.yml
+++ b/.github/workflows/openqa.yml
@@ -8,11 +8,12 @@ on:
   # branch. This is necessary to allow accessing the API credential secrets.
   workflow_dispatch:
 env:
-  OPENQA_HOST: ${{ secrets.OPENQA_URL }}
+  OPENQA_HOST: ${{ secrets.OPENQA_URL || 'https://openqa.opensuse.org' }}
   OPENQA_API_KEY: ${{ secrets.OPENQA_API_KEY }}
   OPENQA_API_SECRET: ${{ secrets.OPENQA_API_SECRET }}
   GH_REPO: ${{ github.event.pull_request.head.repo.full_name }}
   GH_REF: ${{ github.event.pull_request.head.ref }}
+  OPENQA_GROUP_ID: ${{ secrets.OPENQA_GROUP_ID || '1' }}
 
 jobs:
   trigger_and_monitor_openqa:
@@ -25,20 +26,20 @@ jobs:
         id: latest_build
         run: >-
           echo build=$(openqa-cli api
-          --host ${OPENQA_HOST:-https://openqa.opensuse.org}
-          job_groups/${OPENQA_GROUP_ID:-1}/build_results only_tagged=1
+          --host $OPENQA_HOST
+          job_groups/$OPENQA_GROUP_ID/build_results only_tagged=1
           | jq -r '[ .build_results[] | select(.tag.description=="published") | .build ][0]'
           ) >> "$GITHUB_OUTPUT"
       - name: Link to test result overview page
         run: >-
           build=$(tr '/' ':' <<<"$GH_REPO#$GH_REF");
           build=$(perl -e 'use Mojo::Util; print(Mojo::Util::url_escape($ARGV[0]))' "$build");
-          echo "${OPENQA_HOST:-https://openqa.opensuse.org}/tests/overview?flavor=dev&build=$build"
+          echo "$OPENQA_HOST/tests/overview?flavor=dev&build=$build"
       - name: Trigger and monitor openQA test
         run: >-
           openqa-cli schedule
           --monitor
-          --host "${OPENQA_HOST:-https://openqa.opensuse.org}/"
+          --host "$OPENQA_HOST/"
           --apikey "$OPENQA_API_KEY" --apisecret "$OPENQA_API_SECRET"
           --param-file SCENARIO_DEFINITIONS_YAML=scenario-definitions.yaml
           DISTRI=openQA VERSION=Tumbleweed FLAVOR=dev ARCH=x86_64


### PR DESCRIPTION
Default values can already be set in the `env` block.

Related issue: https://progress.opensuse.org/issues/188310