### PR TITLE
Refresh when installing retry like elsewhere

### DIFF
--- a/tests/install/prepare.pm
+++ b/tests/install/prepare.pm
@@ -9,7 +9,8 @@ sub run {
     assert_script_run('semanage boolean -m -1 httpd_can_network_connect');
 
     disable_packagekit;
-    assert_script_run('for i in {1..7}; do zypper --no-cd -n in retry && break; sleep $((i**2*20)); done');
+    # Avoid install_packages which relies on retry being installed
+    assert_script_run('for i in {1..7}; do zypper -n --gpg-auto-import-keys ref && zypper --no-cd -n in retry && break; sleep $((i**2*20)); done');
     assert_script_run('zypper --no-cd -n rm xscreensaver');
     assert_script_run('pkill -f xscreensaver');
 }


### PR DESCRIPTION
We have to keep the inline retry loop since install_packages relies on retry. But without ref the package may be outdated.

See: https://progress.opensuse.org/issues/188349