### PR TITLE
Use uefi for openQA-in-openQA jobs

### DIFF
--- a/.github/workflows/openqa.yml
+++ b/.github/workflows/openqa.yml
@@ -43,6 +43,6 @@ jobs:
           --apikey "$OPENQA_API_KEY" --apisecret "$OPENQA_API_SECRET"
           --param-file SCENARIO_DEFINITIONS_YAML=scenario-definitions.yaml
           DISTRI=openQA VERSION=Tumbleweed FLAVOR=dev ARCH=x86_64
-          HDD_1=opensuse-Tumbleweed-x86_64-${{ steps.latest_build.outputs.build }}-minimalx@64bit.qcow2
+          HDD_1=opensuse-Tumbleweed-x86_64-${{ steps.latest_build.outputs.build }}-minimalx@uefi.qcow2
           BUILD=$(tr '/' ':' <<<"$GH_REPO#$GH_REF") _GROUP_ID=0
           CASEDIR="$GITHUB_SERVER_URL/$GH_REPO.git#$GH_REF"

--- a/scenario-definitions.yaml
+++ b/scenario-definitions.yaml
@@ -10,15 +10,18 @@ products:
       NEEDLES_DIR: "https://github.com/os-autoinst/os-autoinst-needles-openQA"
 
 machines:
-  64bit-2G:
+  uefi-2G:
     backend: qemu
     settings:
       <<: &machine_defaults
         HDDSIZEGB: "20"
         QEMUCPU: host
         WORKER_CLASS: qemu_x86_64
+        UEFI: '1'
+        UEFI_PFLASH_CODE: /usr/share/qemu/ovmf-x86_64-ms-code.bin
+        UEFI_PFLASH_VARS: ovmf-x86_64-ms-vars-800x600.qcow2
       QEMURAM: "2048"
-  64bit-4G:
+  uefi-4G:
     backend: qemu
     settings:
       <<: *machine_defaults
@@ -26,11 +29,11 @@ machines:
 
 .common: &common
   product: openqa-*-dev-x86_64
-  machine: 64bit-2G
+  machine: uefi-2G
 
 .common_4g: &common_4g
   product: openqa-*-dev-x86_64
-  machine: 64bit-4G
+  machine: uefi-4G
 
 job_templates:
   openqa_from_git:


### PR DESCRIPTION
Issueis:
* https://progress.opensuse.org/issues/188310
* https://progress.opensuse.org/issues/188349

64bit images apparently can be too outdated to be able to install anything with zypper.


VR: https://openqa.opensuse.org/tests/5289237#step/prepare/11 (I cancelled the job after the installation step)