### PR TITLE
Fix race condition trying to look at "running" jobs

### DIFF
--- a/tests/osautoinst/test_running.pm
+++ b/tests/osautoinst/test_running.pm
@@ -3,13 +3,11 @@ use testapi;
 use utils;
 
 sub run ($self) {
-    my $api_query = get_var('FULL_MM_TEST') ? 'test=ping_client' : 'state=running state=done';
-    my $success = get_var('FULL_MM_TEST') ? 'passed' : 'passed\|running';
     assert_script_run qq{retry -s 15 -r 120 -- sh -c '
-        r=`openqa-cli api jobs $api_query | tee /dev/fd/2 |
+        r=`openqa-cli api jobs state=done | tee /dev/fd/2 |
         jq -r ".jobs | max_by(.id) | if .result != \\"none\\" then .result else .state end"`;
         echo \$r | grep -q "incomplete\\|failed" && killall retry;
-        echo \$r | grep -q "$success"'}, timeout => 1830;
+        echo \$r | grep -q "passed"'}, timeout => 1830;
     if (get_var('FULL_MM_TEST')) {
         # we can't upload logs if the multimachine OVS bridge in the SUT has the same IP as the openQA-worker host
         script_run 'ip a del 10.0.2.2/15 dev br1'; # This may fail in case this IP is not actually set on the bridge


### PR DESCRIPTION
https://openqa.opensuse.org/tests/5340329#step/tests/3 shows in a
successful job how the "openqa-scheduled-test" matches on a finished job
which is potentially the most likely case which I have also encountered
as before. https://openqa.opensuse.org/tests/5340327#step/tests/4 failed
as the job row is matched but the job is in "running" and the screen was
not fully loaded yet hence the screen content moved before the click
attempt could be made.

If we would back to the former double screen check then there is still a
race condition that the click is acting on a moved screen. If we want to 
check the rendering of the tests page it is safer to be done on a static
job, e.g. one that is either staying scheduled indefinitely or already
ensured to be "done" which is simpler, consistent, reliables. That
makes this related to 
https://github.com/os-autoinst/os-autoinst-distri-openQA/pull/75 with
commit 176a33f that introduced to check for "done" jobs as well next to 
"running". Instead we should check *only* for done jobs. With that this
also builds upon 9f8e01b which unified test result parsing which was
made pretty messy in 97ae6a7 by coming up with different queries and
different expected results.

So this commit harmonizes the query to look for the same expected end
result regardless of FULL_MM_TEST and hence also preventing any impact
of running jobs being displayed in a different position or changing
position or state. As most jobs already end up being "done" before the
test checks for the result we can rely on *all* jobs to end up there
before continuing the check.

Verification (200/200 passed):
https://openqa.opensuse.org/tests/overview?build=%3ATW.39466-poo188043-okurz-pr255

Related progress issue: https://progress.opensuse.org/issues/188043