### PR TITLE
Prevent cloning useless assets to fix stability and optimize

### DIFF
--- a/scenario-definitions.yaml
+++ b/scenario-definitions.yaml
@@ -21,8 +21,6 @@ machines:
       QEMUCPU: host
       WORKER_CLASS: qemu_x86_64
       UEFI: '1'
-      UEFI_PFLASH_CODE: /usr/share/qemu/ovmf-x86_64-ms-code.bin
-      UEFI_PFLASH_VARS: ovmf-x86_64-ms-vars-800x600.qcow2
       QEMURAM: "4096"
 
 .common: &common

--- a/tests/osautoinst/start_test.pm
+++ b/tests/osautoinst/start_test.pm
@@ -2,6 +2,8 @@ use Mojo::Base 'openQAcoretest', -signatures;
 use testapi;
 use utils;
 
+use constant CLONE_ARGS => 'ASSET_1= ASSET_2= ASSET_256= ASSET_LIBVIRT= ASSET_VIRTUALBOX= ISO=';
+
 sub fetch_job_id($groupid, $ttest, $flavor, $openqa_url) {
     # Stores the job id of the latest $ttest job for the most recent Tumbleweed build with matching architecture in $job_id on the shell on the SUT
     my $arch = get_var('ARCH');
@@ -21,14 +23,14 @@ sub full_run {
     # clone the latest "minimalx" job for the most recent Tumbleweed build with matching architecture
     my $openqa_url = get_var('OPENQA_HOST', 'https://openqa.opensuse.org');
     fetch_job_id(1, 'minimalx', 'NET', $openqa_url);
-    assert_script_run("retry -r 5 -e -- openqa-clone-job --show-progress --from $openqa_url \$job_id", timeout => 300);
+    assert_script_run("retry -r 5 -e -- openqa-clone-job --show-progress --from $openqa_url \$job_id " . CLONE_ARGS, timeout => 300);
 }
 
 sub full_run_multimachine {
     # clone the latest "ping_client" MM job for the most recent Tumbleweed build with matching architecture
     my $openqa_url = get_var('OPENQA_HOST', 'https://openqa.opensuse.org');
     fetch_job_id(1, 'ping_client', 'DVD', $openqa_url);
-    assert_script_run("retry -r 5 -e -- openqa-clone-job --show-progress --skip-chained-deps --from $openqa_url \$job_id", timeout => 600);
+    assert_script_run("retry -r 5 -e -- openqa-clone-job --show-progress --skip-chained-deps --from $openqa_url \$job_id " . CLONE_ARGS, timeout => 600);
 }
 
 sub example_run {


### PR DESCRIPTION
Relevant progress issue: https://progress.opensuse.org/issues/193345

```
openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-openQA/pull/266 https://openqa.opensuse.org/tests/5495667
```

openqa-Tumbleweed-dev-x86_64-Build:TW.40550-openqa_install_multimachine@uefi-4G -> https://openqa.opensuse.org/tests/5495731

