### PR TITLE
feat: retry on "zypper ar" problems as well

### DIFF
--- a/tests/install/openqa_webui.pm
+++ b/tests/install/openqa_webui.pm
@@ -15,7 +15,7 @@ sub add_repo {
 
     # Avoid using the redirector service to cope with transient repo content
     my $repo_url = get_var('OPENQA_REPO_URL', "https://downloadcontent.opensuse.org/repositories/$project/$repo");
-    assert_script_run("zypper -n ar -p 95 -f '$repo_url' openQA");
+    assert_script_run("retry -e -s 30 -r 7 -- zypper -n ar -p 95 -f '$repo_url' openQA");
     assert_script_run('retry -e -s 30 -r 7 -- zypper -n --gpg-auto-import-keys ref', timeout => 4000);
 }
 


### PR DESCRIPTION
repositories in particular in the OBS "devel" scope can be temporarily
invalid which triggered problems on "zypper ar" calls so we should
conduct retries in such cases as well.

Related issue: https://progress.opensuse.org/issues/198773