### PR TITLE
refactor: Change tag to openqa-present-test 

### DIFF
--- a/tests/openQA/tests.pm
+++ b/tests/openQA/tests.pm
@@ -22,7 +22,7 @@ sub visit_test($needle) {
 }
 
 sub run {
-    visit_test 'openqa-scheduled-test';
+    visit_test 'openqa-present-test';
 }
 
 1;


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/198992

The tag is supposed to match tests with several kinds of states on the all
tests page, not only scheduled.

The status is reflected in the needle filenames.

Needs:
* https://github.com/os-autoinst/os-autoinst-needles-openQA/pull/38

Tested in my local instance.