### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,6 +1,8 @@
 ---
 name: Various Checks
 # yamllint disable-line rule:truthy
+permissions:
+  contents: read
 on: [push, pull_request]
 
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/os-autoinst/os-autoinst-distri-openQA/security/code-scanning/2](https://github.com/os-autoinst/os-autoinst-distri-openQA/security/code-scanning/2)

In general, the fix is to explicitly declare a least-privilege `permissions:` block so that the `GITHUB_TOKEN` used in this workflow is limited. Because this workflow only checks out code and validates YAML, it needs only read access to repository contents; it does not need write access to any scopes.

The best fix here is to add a workflow-level `permissions:` block (applies to all jobs) specifying `contents: read`. This should be placed at the top level of `.github/workflows/check.yaml`, alongside `name:` and `on:`, before the `jobs:` key. Concretely, after line 3 (the comment) and before line 4 (`on: [push, pull_request]`), insert:

```yaml
permissions:
  contents: read
```

No imports, methods, or other definitions are needed; this is purely a configuration change in the YAML workflow file and does not alter any functional steps.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
