### PR TITLE
chore(ci): bump checkout to v6

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -11,7 +11,7 @@ jobs:
     container:
       image: registry.opensuse.org/devel/openqa/containers/tumbleweed:client
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Validate yaml
         run: |-
           curl https://openqa.opensuse.org/schema/JobScenarios-01.yaml -O

--- a/.github/workflows/openqa.yml
+++ b/.github/workflows/openqa.yml
@@ -23,7 +23,7 @@ jobs:
     container:
       image: registry.opensuse.org/devel/openqa/containers/tumbleweed:client
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Get latest build
         id: latest_build
         run: >-


### PR DESCRIPTION
This also fixes a warning about outdated nodejs