### PR TITLE
fix: increase assert_screen timeout in wait_for_desktop

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -43,7 +43,7 @@ sub handle_gui_password {
 }
 
 sub wait_for_desktop {
-    assert_screen([qw/boot-menu openqa-desktop/]);
+    assert_screen([qw/boot-menu openqa-desktop/], 500);
     send_key 'ret' if match_has_tag('boot-menu');
     assert_screen 'openqa-desktop', 500;
     return if match_has_tag('generic-desktop');


### PR DESCRIPTION
Give more time to resolve needle match failure after reboot

Issue: https://progress.opensuse.org/issues/199217