### PR TITLE
feat: enable LLM failure analysis

### DIFF
--- a/scenario-definitions.yaml
+++ b/scenario-definitions.yaml
@@ -8,6 +8,7 @@ products:
     settings:
       CASEDIR: "https://github.com/os-autoinst/os-autoinst-distri-openQA"
       NEEDLES_DIR: "https://github.com/os-autoinst/os-autoinst-needles-openQA"
+      LLM_FAILURE_ANALYSIS: "1"
   
   openqa-*-dev-full-x86_64:
     <<: *default_product


### PR DESCRIPTION
With https://github.com/os-autoinst/os-autoinst/pull/2857 os-autoinst
supports an optional LLM failure analysis. We can test this out in
openQA-in-openQA tests.

Related issue: https://progress.opensuse.org/issues/199178