### PR TITLE
fix: require SUT reboot for NetworkManager in multi-machine tests

### DIFF
--- a/tests/install/openqa_worker.pm
+++ b/tests/install/openqa_worker.pm
@@ -30,6 +30,11 @@ EOF
     assert_script_run "systemctl enable --now openqa-worker@2" if get_var('FULL_MM_TEST');
     save_screenshot;
     clear_root_console;
+    if (script_run('systemctl is-active NetworkManager.service') == 0) {
+        assert_script_run('systemctl reboot');
+        wait_for_desktop;
+        login;
+    }
 }
 
 1;


### PR DESCRIPTION
Ticket: https://progress.opensuse.org/issues/199742  
Validation Test: https://openqa.opensuse.org/tests/5881635#step/openqa_worker/23  

Updates the worker setup process to conditionally reboot the SUT when NetworkManager is in use, ensuring the network configurations applied by `os-autoinst-setup-multimachine` take effect properly.
