### PR TITLE
fix: ensure br1 for cleanup and prevent timeout from get_logs

### DIFF
--- a/lib/openQAcoretest.pm
+++ b/lib/openQAcoretest.pm
@@ -7,7 +7,8 @@ sub post_fail_hook ($self) {
     switch_to_root_console;
     send_key 'ctrl-c';     # Stop current command, if any
     # we can't upload logs if the multimachine OVS bridge in the SUT has the same IP as the openQA-worker host
-    script_run 'ip a del 10.0.2.2/15 dev br1'; # This may fail in case this IP is not actually set on the bridge
+    # This may fail in case this IP is not actually set on the bridge
+    script_run 'ip link show br1 && ip a del 10.0.2.2/15 dev br1';
     if (get_var('OPENQA_FROM_GIT')) {
         assert_script_run 'cd /root/openQA';
         enter_cmd 'script/openqa-cli api jobs';

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -8,7 +8,7 @@ use File::Basename qw(basename);
 our @EXPORT = qw(get_log install_packages clear_root_console switch_to_root_console switch_to_x11 wait_for_desktop login ensure_unlocked_desktop wait_for_container_log prepare_firefox_autoconfig disable_packagekit);
 
 sub get_log ($cmd, $name) {
-    my $ret = script_run "$cmd | tee $name";
+    my $ret = script_run "$cmd | tee $name", timeout => 300;
     upload_logs($name) unless $ret;
 }
 

--- a/tests/osautoinst/test_running.pm
+++ b/tests/osautoinst/test_running.pm
@@ -12,7 +12,7 @@ sub run ($self) {
         echo \$r | grep -q "$success"'}, timeout => 1830;
     if (get_var('FULL_MM_TEST')) {
         # we can't upload logs if the multimachine OVS bridge in the SUT has the same IP as the openQA-worker host
-        script_run 'ip a del 10.0.2.2/15 dev br1'; # This may fail in case this IP is not actually set on the bridge
+        script_run 'ip link show br1 && ip a del 10.0.2.2/15 dev br1';
         $self->upload_openqa_logs;
     }
     save_screenshot;


### PR DESCRIPTION
Skip `ip a del` on br1 when the bridge doesn't exist, preventing unnecessary errors in test_running and post_fail_hook. Increase get_log timeout to 300s to prevent journalctl dumps from timing out.