### PR TITLE
fix: skip unnecessary login after switch to 'None' provider

### DIFF
--- a/main.pm
+++ b/main.pm
@@ -45,7 +45,7 @@ sub load_openQA_tests() {
     }
     else {
       loadtest 'openQA/dashboard';
-      loadtest 'openQA/login';
+      loadtest 'openQA/login' unless get_var('OPENQA_FROM_BOOTSTRAP');
       # testing from git does not schedule tests so far
       loadtest 'openQA/tests' unless get_var('OPENQA_FROM_GIT');
     }

--- a/tests/containers/worker.pm
+++ b/tests/containers/worker.pm
@@ -5,7 +5,7 @@ use utils;
 sub run {
   my $volumes = '-v "/root/data/factory:/data/factory" -v "/root/data/tests:/data/tests" -v "/root/openQA/container/openqa_data/data.template/conf/:/data/conf:ro"';
   assert_script_run("docker run -d --network testing $volumes --name openqa_worker openqa_worker");
-  wait_for_container_log('openqa_worker', 'API key and secret are needed', 'docker');
+  wait_for_container_log('openqa_worker', '(Registering with openQA|API key and secret are needed)', 'docker');
   clear_root_console;
 }
 


### PR DESCRIPTION
Related issue: https://progress.opensuse.org/issues/194786