### PR TITLE
fix: handle older still-needed login gracefully

### DIFF
--- a/main.pm
+++ b/main.pm
@@ -45,7 +45,7 @@ sub load_openQA_tests() {
     }
     else {
       loadtest 'openQA/dashboard';
-      loadtest 'openQA/login' unless get_var('OPENQA_FROM_BOOTSTRAP');
+      loadtest 'openQA/login';
       # testing from git does not schedule tests so far
       loadtest 'openQA/tests' unless get_var('OPENQA_FROM_GIT');
     }

--- a/tests/openQA/login.pm
+++ b/tests/openQA/login.pm
@@ -2,7 +2,9 @@ use Mojo::Base 'openQAcoretest';
 use testapi;
 
 sub run {
-    assert_and_click 'openqa-login';
+    assert_screen [qw(openqa-logged-in openqa-login)];
+    return undef if match_has_tag 'openqa-logged-in';
+    click_lastmatch;
     assert_screen 'openqa-logged-in';
 }
 


### PR DESCRIPTION
older versions of openQA without the 'None' provider still need an
explicit login.

Related issue: https://progress.opensuse.org/issues/194786