### PR TITLE
Run super post_fail_hook first for consistent state

### DIFF
--- a/tests/install/openqa_webui.pm
+++ b/tests/install/openqa_webui.pm
@@ -118,13 +118,13 @@ sub run {
 }
 
 sub post_fail_hook ($self) {
+    $self->SUPER::post_fail_hook;
+
     get_log 'tail -n 50000 /var/log/zypper.log' => 'zypper.log.txt';
     get_log 'ls -lRa /var/cache/zypp/raw/' => 'repodata.log.txt';
     assert_script_run('zypper -n --gpg-auto-import-keys ref', timeout => 600);
     get_log 'tail -n 800 /var/log/zypper.log' => 'zypper1.log.txt';
     get_log 'ls -lRa /var/cache/zypp/raw/' => 'repodata1.log.txt';
-
-    $self->SUPER::post_fail_hook;
 }
 
 1;


### PR DESCRIPTION
Otherwise the following commands may fail to run for unrelated reasons to the error they are meant to help with.

See: https://progress.opensuse.org/issues/201537