### PR TITLE
feat: use proper "select_console" calls

### DIFF
--- a/lib/openQAcoretest.pm
+++ b/lib/openQAcoretest.pm
@@ -1,10 +1,10 @@
 package openQAcoretest;
 use Mojo::Base 'basetest', -signatures;
 use testapi;
-use utils qw(switch_to_root_console get_log);
+use utils qw(get_log);
 
 sub post_fail_hook ($self) {
-    switch_to_root_console;
+    select_console 'root-console';
     send_key 'ctrl-c';     # Stop current command, if any
     # we can't upload logs if the multimachine OVS bridge in the SUT has the same IP as the openQA-worker host
     # This may fail in case this IP is not actually set on the bridge

--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -1,6 +1,16 @@
 package susedistribution;
-use base 'distribution';
+use Mojo::Base 'distribution', -signatures;
+use File::Basename qw(basename);
+use testapi qw(get_required_var check_var);
 
-# Base class for all test modules
+sub init ($self) {
+    $self->SUPER::init();
+    $self->add_console('root-console', 'tty-console', {tty => 3});
+    my @hdd = split(/-/, basename get_required_var('HDD_1'));
+    # older openSUSE Tumbleweed has x11 still on tty7
+    # minimalx has x11 on tty7
+    $self->add_console('x11', 'tty-console', {tty => ($hdd[3] < 20190617 or check_var('DESKTOP', 'minimalx')) ? 7 : 2});
+;
+}
 
 1;

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -3,9 +3,8 @@ package utils;
 use Mojo::Base 'Exporter', -signatures;
 use Exporter;
 use testapi;
-use File::Basename qw(basename);
 
-our @EXPORT = qw(get_log install_packages clear_root_console switch_to_root_console switch_to_x11 wait_for_desktop login ensure_unlocked_desktop wait_for_container_log prepare_firefox_autoconfig disable_packagekit);
+our @EXPORT = qw(get_log install_packages clear_root_console wait_for_desktop login ensure_unlocked_desktop wait_for_container_log prepare_firefox_autoconfig disable_packagekit);
 
 sub get_log ($cmd, $name) {
     my $ret = script_run "$cmd | tee $name", timeout => 300;
@@ -21,18 +20,6 @@ sub clear_root_console {
     enter_cmd 'clear';
     enter_cmd 'cd';
     assert_screen 'root-console';
-}
-
-sub switch_to_root_console {
-    send_key 'ctrl-alt-f3';
-}
-
-sub switch_to_x11 {
-    my @hdd = split(/-/, basename get_required_var('HDD_1'));
-    # older openSUSE Tumbleweed has x11 still on tty7
-    # minimalx has x11 on tty7
-    my $x11_tty = ($hdd[3] < 20190617 or check_var('DESKTOP', 'minimalx')) ? 'f7' : 'f2';
-    send_key "ctrl-alt-$x11_tty";
 }
 
 sub handle_gui_password {
@@ -59,7 +46,7 @@ sub wait_for_desktop {
 }
 
 sub login {
-    switch_to_root_console;
+    select_console 'root-console';
     assert_screen 'inst-console';
     type_string "root\n";
     assert_screen 'password-prompt';

--- a/tests/install/prepare.pm
+++ b/tests/install/prepare.pm
@@ -1,6 +1,6 @@
 use Mojo::Base 'openQAcoretest';
 use testapi;
-use utils qw(login disable_packagekit switch_to_root_console);
+use utils qw(login disable_packagekit);
 
 sub run {
     login;

--- a/tests/install/test_distribution.pm
+++ b/tests/install/test_distribution.pm
@@ -18,7 +18,7 @@ sub run {
     clear_root_console;
     # prepare for next test
     enter_cmd 'logout';
-    switch_to_x11;
+    select_console 'x11';
 }
 
 1;

--- a/tests/install/worker_ay_validation.pm
+++ b/tests/install/worker_ay_validation.pm
@@ -4,7 +4,7 @@ use testapi;
 use utils;
 
 sub run {
-    switch_to_root_console;
+    select_console 'root-console';
     my $profile = '/root/result.xml';
     install_packages('autoyast2 libxml2-tools');
     my $template_path = get_required_var('AUTOYAST');

--- a/tests/openQA/dashboard.pm
+++ b/tests/openQA/dashboard.pm
@@ -6,7 +6,7 @@ use OpenQA::Wheel::Launcher 'start_gui_program';
 
 sub run {
     prepare_firefox_autoconfig;
-    switch_to_x11;
+    select_console 'x11';
     ensure_unlocked_desktop();
     start_gui_program('firefox http://localhost', 60, valid => 1);
     #wait few minutes for ff to start and then fail the test

--- a/tests/openQA/search.py
+++ b/tests/openQA/search.py
@@ -14,12 +14,8 @@ def run(self):
     assert_screen('openqa-search-results')
 
 
-def switch_to_root_console():
-    send_key('ctrl-alt-f3')
-
-
 def post_fail_hook(self):
-    switch_to_root_console()
+    select_console('root-console')
     assert_script_run('openqa-cli api experimental/search q=shutdown.pm')
 
 

--- a/tests/osautoinst/worker.pm
+++ b/tests/osautoinst/worker.pm
@@ -1,11 +1,10 @@
 use Mojo::Base 'openQAcoretest';
 use testapi;
-use utils qw(wait_for_desktop switch_to_root_console clear_root_console);
+use utils qw(wait_for_desktop clear_root_console);
 
 sub run {
     wait_for_desktop;
-    switch_to_root_console;
-    assert_screen 'inst-console';
+    select_console 'root-console';
     type_string "root\n";
     assert_screen 'password-prompt';
     type_password;

--- a/tests/shutdown/shutdown.pm
+++ b/tests/shutdown/shutdown.pm
@@ -1,11 +1,8 @@
 use Mojo::Base 'openQAcoretest';
 use testapi;
-use utils qw(switch_to_root_console);
 
 sub run {
-    switch_to_root_console;
-    enter_cmd 'cd';
-    assert_screen 'root-console';
+    select_console 'root-console';
     enter_cmd 'poweroff';
     assert_shutdown 300;
 }


### PR DESCRIPTION
Instead of manually switching tty's with no consistent synchronisation
we should use the "proper" os-autoinst provided way to define
consoles with "add_console" and use them with "select_console". This
change simplifies code, clarifies the intention and prevents
synchronisation issues when actions are conducted before the
availability of fully logged in terminals was ensured.