### PR TITLE
feat(worker_ay_validation): use wget internal retry on host error

### DIFF
--- a/tests/install/worker_ay_validation.pm
+++ b/tests/install/worker_ay_validation.pm
@@ -9,7 +9,7 @@ sub run {
     install_packages('autoyast2 libxml2-tools');
     my $template_path = get_required_var('AUTOYAST');
     my $profile_template = basename($template_path);
-    assert_script_run "wget $template_path";
+    assert_script_run "wget --retry-on-host-error $template_path";
     # run-scripts=true is not used because the salt-minion is not installed in the VM
     enter_cmd "yast2 autoyast check-profile filename=$profile_template output=$profile run-erb=true";
     assert_screen "check-autoyast-profile-ok", timeout => 300;


### PR DESCRIPTION
Same as done in osautoinst/start_test.pm where we also use wget.