### PR TITLE
ci: disable Mergify interactive queue controls in PR comments

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,3 +1,7 @@
+---
+merge_queue:
+  status_comments: none
+  queue_controls_comment: false
 pull_request_rules:
   - name: automatic merge
     conditions:


### PR DESCRIPTION
Motivation: Rendered task-list checkboxes in the Merge Queue status comment
could be clicked accidentally by reviewers, triggering unexpected merges
before the required approval count was met.

Design Choices: Set queue_controls_comment to false in the merge_queue block
of .mergify.yml to disable rendering these interactive controls.

Benefits: Prevents accidental manual queueing and merging of pull requests
while allowing automated queues like Dependabot to work normally.