### PR TITLE
Be forgiving when downloading scenario definitions

### DIFF
--- a/tests/osautoinst/start_test.pm
+++ b/tests/osautoinst/start_test.pm
@@ -44,7 +44,7 @@ sub example_run {
     my $arch = get_var('ARCH');
     my $casedir = 'https://github.com/os-autoinst/os-autoinst-distri-example.git';
     my $needlesdir = '%%CASEDIR%%/needles';
-    assert_script_run 'wget --retry-on-host-error https://raw.githubusercontent.com/os-autoinst/os-autoinst-distri-example/main/scenario-definitions.yaml';
+    assert_script_run 'wget --retry-on-host-error --retry-on-http-error=429 --tries=5 --waitretry=10 --random-wait https://raw.githubusercontent.com/os-autoinst/os-autoinst-distri-example/main/scenario-definitions.yaml';
     assert_script_run "openqa-cli schedule --param-file SCENARIO_DEFINITIONS_YAML=scenario-definitions.yaml DISTRI=example VERSION=0 FLAVOR=DVD ARCH=$arch TEST=simple_boot _GROUP_ID=0 BUILD=test CASEDIR=$casedir NEEDLES_DIR=$needlesdir";
 
 }


### PR DESCRIPTION
Rate limiting results in 429 errors, and we should wait and retry in that case.

See: https://progress.opensuse.org/issues/203856