### PR TITLE
fix: Work around libsvtav1 crashing in nested test

### DIFF
--- a/tests/install/openqa_worker.pm
+++ b/tests/install/openqa_worker.pm
@@ -2,6 +2,12 @@ use Mojo::Base 'openQAcoretest';
 use testapi;
 use utils;
 
+# work around libsvtav1 crashing in the VM without `-svtav1-params lp=…`
+# see https://progress.opensuse.org/issues/204756#note-5 and https://gitlab.com/AOMediaCodec/SVT-AV1/-/work_items/2383
+use constant DEFAULT_FFMPEG_CMD => 'ffmpeg -y -hide_banner -nostats -r 24 -f image2pipe -vcodec ppm -i - -pix_fmt yuv420p';
+use constant SVTAV1_LP1_CMD => DEFAULT_FFMPEG_CMD . ' -c:v libsvtav1 -svtav1-params lp=1 -crf 50 -preset 7 -b:v 0';
+use constant ENCODER_SETTINGS => 'EXTERNAL_VIDEO_ENCODER_CMD = ' . SVTAV1_LP1_CMD;
+
 sub run {
     diag('worker setup');
     install_packages('openQA-worker', 3800);
@@ -20,6 +26,7 @@ EOF
         my $class = "WORKER_CLASS=qemu_$arch,tap";
         assert_script_run sprintf q{if [ -e /etc/openqa/workers.ini ]; then sed -i -e "s/\(\[global\]\)/\1\n%s/" /etc/openqa/workers.ini; else echo -e "[global]\n%s" > /etc/openqa/workers.ini.d/base.ini; fi}, $class, $class;
     }
+    assert_script_run sprintf q{echo -e "[global]\n%s" > /etc/openqa/workers.ini.d/enc.ini}, ENCODER_SETTINGS;
     assert_script_run('os-autoinst-setup-multi-machine', timeout => 120);
     my $worker_setup = <<'EOF';
 systemctl status --no-pager os-autoinst-openvswitch


### PR DESCRIPTION
After the SVT-AV1 encoder lib was updated in TW from v3.0.0 to v4.2.0 it crashes when executed in our virtualized test environment. (This can be reproduced by cloning a job of flavor `dev-full`. It does not crash when ffmpeg/libsvtav1 is executed on a bare metal host. Hence, when cloning on a TW host, only the inner test fails.)

It helps to set the level of parallelism explicitly. So this change sets it explicitly to 1 via `-svtav1-params lp=1` which is in accordance with what is otherwise automatically detected inside our test VM. So this change should not make any difference but apparently this way libstav1 no longer crashes.

Note that these crashes are reproducible 100 % of the time and without specifying the level of parallelism. When specifying it (the exact level being specified does not matter) I could not reproduce one crash so far.

Note that using `-svtav1-params asm=0` does not make a difference. (So it still crashes with `asm level selected : up to c`.)

Related ticket: https://progress.opensuse.org/issues/204756