### PR TITLE
feat: Avoid needless logout and re-login

### DIFF
--- a/tests/install/test_distribution.pm
+++ b/tests/install/test_distribution.pm
@@ -15,10 +15,8 @@ sub run {
     # /etc/zypp/zypp.conf so we need to refresh explicitly with retries in
     # case of problems.
     install_packages('os-autoinst-distri-opensuse-deps');
+    # leave clean root console for subsequent test (if the next module needs x11 it can switch itself)
     clear_root_console;
-    # prepare for next test
-    enter_cmd 'logout';
-    select_console 'x11';
 }
 
 1;

--- a/tests/osautoinst/worker.pm
+++ b/tests/osautoinst/worker.pm
@@ -3,13 +3,6 @@ use testapi;
 use utils qw(wait_for_desktop clear_root_console);
 
 sub run {
-    wait_for_desktop;
-    select_console 'root-console';
-    type_string "root\n";
-    assert_screen 'password-prompt';
-    type_password;
-    send_key 'ret';
-    wait_still_screen(2);
     assert_script_run 'systemctl status --no-pager openqa-worker@1 | grep --color -z "active (running)"';
     script_run('dmesg -D'); # workaround for bsc#1217397
     save_screenshot;


### PR DESCRIPTION
* Leave a clean root console in the `test_distribution` test module
* Remove the error prone code in the `worker` test module to re-login (it is error prone as it lacks `assert_screen 'inst-console';` as done in `utils::login`)
* Note that the `dashboard` test module already has `select_console 'x11';` so there is not need for `test_distribution` doing the same

Related ticket: https://progress.opensuse.org/issues/205527