### PR TITLE
fix: Retry wget on 503 and increase wait times

### DIFF
--- a/tests/osautoinst/start_test.pm
+++ b/tests/osautoinst/start_test.pm
@@ -44,7 +44,7 @@ sub example_run {
     my $arch = get_var('ARCH');
     my $casedir = 'https://github.com/os-autoinst/os-autoinst-distri-example.git';
     my $needlesdir = '%%CASEDIR%%/needles';
-    assert_script_run 'wget --retry-on-host-error --retry-on-http-error=429 --tries=5 --waitretry=10 --random-wait https://raw.githubusercontent.com/os-autoinst/os-autoinst-distri-example/main/scenario-definitions.yaml';
+    assert_script_run 'wget --retry-on-host-error --retry-on-http-error=429,503 --tries=15 --waitretry=30 --random-wait https://raw.githubusercontent.com/os-autoinst/os-autoinst-distri-example/main/scenario-definitions.yaml', timeout => 600;
     assert_script_run "openqa-cli schedule --param-file SCENARIO_DEFINITIONS_YAML=scenario-definitions.yaml DISTRI=example VERSION=0 FLAVOR=DVD ARCH=$arch TEST=simple_boot _GROUP_ID=0 BUILD=test CASEDIR=$casedir NEEDLES_DIR=$needlesdir";
 
 }


### PR DESCRIPTION
Motivation:
GitHub occasionally responds with 503 Service Unavailable when fetching
scenario definitions, causing openQA tests to fail.

Design Choices:
Include 503 in the wget --retry-on-http-error list, increase --tries to 15,
raise --waitretry to 30 seconds, and set the step timeout to 10 minutes.

Benefits:
Avoids test failures caused by transient network and service issues on GitHub's
side.

Related issue: https://openqa.opensuse.org/tests/6170955#step/start_test/3